### PR TITLE
Android: Close input and output streams

### DIFF
--- a/android/src/main/java/com/drpogodin/reactnativefs/ReactNativeFsModule.java
+++ b/android/src/main/java/com/drpogodin/reactnativefs/ReactNativeFsModule.java
@@ -37,6 +37,7 @@ import com.facebook.react.ReactActivity;
 import com.facebook.react.modules.core.DeviceEventManagerModule.RCTDeviceEventEmitter;
 
 import java.io.ByteArrayOutputStream;
+import java.io.Closeable;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -62,6 +63,18 @@ public class ReactNativeFsModule extends ReactNativeFsSpec {
 
   private ArrayDeque<Promise> pendingPickFilePromises = new ArrayDeque<Promise>();
   private ActivityResultLauncher<String[]> pickFileLauncher;
+
+  /**
+   * Attempts to close given object, discarting possible exception. Does nothing
+   * if given argument is null.
+   * @param closeable
+   */
+  static private void closeIgnoringException(Closeable closeable) {
+    if (closeable != null) {
+      try { closeable.close(); }
+      catch (Exception e) {}
+    }
+  }
 
   ReactNativeFsModule(ReactApplicationContext context) {
     super(context);
@@ -330,19 +343,10 @@ public class ReactNativeFsModule extends ReactNativeFsSpec {
       }
 
       // Attempt to open file (win = exists)
-      InputStream fileStream = null;
-      try {
-        fileStream = assetManager.open(filepath);
+      try (InputStream fileStream = assetManager.open(filepath)) {
         promise.resolve(true);
       } catch (Exception ex) {
         promise.resolve(false); // don't throw an error, resolve false
-      } finally {
-        if (fileStream != null) {
-          try {
-            fileStream.close();
-          } catch (Exception ignored) {
-          }
-        }
       }
     } catch (Exception ex) {
       ex.printStackTrace();
@@ -450,12 +454,7 @@ public class ReactNativeFsModule extends ReactNativeFsSpec {
       ex.printStackTrace();
       reject(promise, filepath, ex);
     } finally {
-      if (inputStream != null) {
-        try {
-          inputStream.close();
-        } catch (IOException ignored) {
-        }
-      }
+      closeIgnoringException(inputStream);
     }
   }
 
@@ -659,12 +658,7 @@ public class ReactNativeFsModule extends ReactNativeFsSpec {
       ex.printStackTrace();
       reject(promise, filepath, ex);
     } finally {
-      if (stream != null) {
-        try {
-          stream.close();
-        } catch (IOException ignored) {
-        }
-      }
+      closeIgnoringException(stream);
     }
   }
 
@@ -687,12 +681,7 @@ public class ReactNativeFsModule extends ReactNativeFsSpec {
       ex.printStackTrace();
       reject(promise, filename, ex);
     } finally {
-      if (stream != null) {
-        try {
-          stream.close();
-        } catch (IOException ignored) {
-        }
-      }
+      closeIgnoringException(stream);
     }
   }
 
@@ -797,7 +786,7 @@ public class ReactNativeFsModule extends ReactNativeFsSpec {
       promise.resolve(file.setLastModified((long) mtime));
     } catch (Exception ex) {
       ex.printStackTrace();
-     reject(promise, filepath, ex);
+      reject(promise, filepath, ex);
     }
   }
 
@@ -921,18 +910,8 @@ public class ReactNativeFsModule extends ReactNativeFsSpec {
       ex.printStackTrace();
       reject(promise, filepath, ex);
     } finally {
-      if (outputStream != null) {
-        try {
-          outputStream.close();
-        } catch (IOException ignored) {
-        }
-      }
-      if (file != null) {
-        try {
-          file.close();
-        } catch (IOException ignored) {
-        }
-      }
+      closeIgnoringException(outputStream);
+      closeIgnoringException(file);
     }
   }
 
@@ -970,18 +949,8 @@ public class ReactNativeFsModule extends ReactNativeFsSpec {
       } catch (Exception ex) {
         return ex;
       } finally {
-        if (in != null) {
-          try {
-            in.close();
-          } catch (IOException ignored) {
-          }
-        }
-        if (out != null) {
-          try {
-            out.close();
-          } catch (IOException ignored) {
-          }
-        }
+        closeIgnoringException(in);
+        closeIgnoringException(out);
       }
     }
   }
@@ -1010,18 +979,8 @@ public class ReactNativeFsModule extends ReactNativeFsSpec {
     } catch (Exception ex) {
       reject(promise, source, new Exception(String.format("Failed to copy '%s' to %s (%s)", source, destination, ex.getLocalizedMessage())));
     } finally {
-      if (in != null) {
-        try {
-          in.close();
-        } catch (IOException ignored) {
-        }
-      }
-      if (out != null) {
-        try {
-          out.close();
-        } catch (IOException ignored) {
-        }
-      }
+      closeIgnoringException(in);
+      closeIgnoringException(out);
     }
   }
 
@@ -1064,20 +1023,14 @@ public class ReactNativeFsModule extends ReactNativeFsSpec {
 
   private static byte[] getInputStreamBytes(InputStream inputStream) throws IOException {
     byte[] bytesResult;
-    ByteArrayOutputStream byteBuffer = new ByteArrayOutputStream();
     int bufferSize = 1024;
     byte[] buffer = new byte[bufferSize];
-    try {
+    try (ByteArrayOutputStream byteBuffer = new ByteArrayOutputStream()) {
       int len;
       while ((len = inputStream.read(buffer)) != -1) {
         byteBuffer.write(buffer, 0, len);
       }
       bytesResult = byteBuffer.toByteArray();
-    } finally {
-      try {
-        byteBuffer.close();
-      } catch (IOException ignored) {
-      }
     }
     return bytesResult;
   }
@@ -1153,57 +1106,3 @@ public class ReactNativeFsModule extends ReactNativeFsSpec {
     emitter.emit(eventName, params);
   }
 }
-
-/**
- * TODO: This is the original module file
- *
--
--
--
--
--
--
--
--
--
--
--
--
--
--import com.facebook.react.bridge.Promise;
--import com.facebook.react.bridge.ReactApplicationContext;
--
--import com.facebook.react.bridge.ReactContextBaseJavaModule;
--import com.facebook.react.bridge.ReactMethod;
--
-
--
--
--import com.facebook.react.module.annotations.ReactModule;
--
--
--
--
--
--import java.util.HashMap;
--import java.util.Map;
--
--  private static final String RNFSDocumentDirectoryPath = "RNFSDocumentDirectoryPath";
--  private static final String RNFSExternalDirectoryPath = "RNFSExternalDirectoryPath";
--  private static final String RNFSExternalStorageDirectoryPath = "RNFSExternalStorageDirectoryPath";
--  private static final String RNFSPicturesDirectoryPath = "RNFSPicturesDirectoryPath";
--  private static final String RNFSDownloadDirectoryPath = "RNFSDownloadDirectoryPath";
--  private static final String RNFSTemporaryDirectoryPath = "RNFSTemporaryDirectoryPath";
--  private static final String RNFSCachesDirectoryPath = "RNFSCachesDirectoryPath";
--  private static final String RNFSExternalCachesDirectoryPath = "RNFSExternalCachesDirectoryPath";
--  private static final String RNFSDocumentDirectory = "RNFSDocumentDirectory";
--
--  private static final String RNFSFileTypeRegular = "RNFSFileTypeRegular";
--  private static final String RNFSFileTypeDirectory = "RNFSFileTypeDirectory";
--
--  private SparseArray<Downloader> downloaders = new SparseArray<>();
--  private SparseArray<Uploader> uploaders = new SparseArray<>();
--
--  private ReactApplicationContext reactContext;
--
- */

--- a/android/src/main/java/com/drpogodin/reactnativefs/ReactNativeFsModule.java
+++ b/android/src/main/java/com/drpogodin/reactnativefs/ReactNativeFsModule.java
@@ -970,13 +970,17 @@ public class ReactNativeFsModule extends ReactNativeFsSpec {
       } catch (Exception ex) {
         return ex;
       } finally {
-        try {
-          in.close();
-        } catch (IOException ignored) {
+        if (in != null) {
+          try {
+            in.close();
+          } catch (IOException ignored) {
+          }
         }
-        try {
-          out.close();
-        } catch (IOException ignored) {
+        if (out != null) {
+          try {
+            out.close();
+          } catch (IOException ignored) {
+          }
         }
       }
     }
@@ -1151,8 +1155,8 @@ public class ReactNativeFsModule extends ReactNativeFsSpec {
 }
 
 /**
- * TODO: This is the original module file 
- * 
+ * TODO: This is the original module file
+ *
 -
 -
 -


### PR DESCRIPTION
This pull request adds functionality to close streams in Android as discussed in #10.

Previously, the streams were often not closed at function exit, which led to system warnings. If possible, try-with-resources is used. In more complex situations, `close()` is called manually in the finally block.