### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,10 @@ const DocumentDirectoryPath: string;
 
 The absolute path to the document directory.
 
+**IMPORTANT**: `DocumentDirectoryPath` (iOS) will include an ID in the path that changes each build e.g `...Application/BCE32988-4C51-483B-892B-16671E3771C2/Documents`. 
+
+Use relative paths and resolve the full path at runtime to avoid files not being found on new builds.
+
 ### DownloadDirectoryPath
 [DownloadDirectoryPath]: #downloaddirectorypath
 ```ts


### PR DESCRIPTION
Update readme with notes about changing paths for DocumentDirectoryPath on iOS and advice use of relative paths or just filenames to resolve path at runtime

---

I got burnt by this the other because I thought it was safe to store absolute paths in some of data (which is a mistake I know, and I should have known better) but still just making it a note so people know.  Android doesn't have the changing ID part and I had originally designed the app for Android which broke on iOS 