### PR TITLE
Fix bug in conversion of boolean values from RN to ObjC for downloadFile()

### DIFF
--- a/README.md
+++ b/README.md
@@ -1248,8 +1248,8 @@ The type of options argument of [downloadFile()].
   Defaults _false_.
 
 - `discretionary` &mdash; **boolean** &mdash; Optional. Allow the OS to control
-  the timing and speed of the download to improve perceived performance
-  (iOS only).
+  the timing and speed of the download to improve perceived performance. This setting may prevent downloading with mobile internet or when the battery is low. Only works when `background` is activated
+  (iOS only, defaults to _false_).
 - `cacheable` &mdash; **boolean** &mdash; Optional. Whether the download can be
   stored in the shared NSURLCache (iOS only, defaults to _true_).
 

--- a/ios/ReactNativeFs.h
+++ b/ios/ReactNativeFs.h
@@ -40,18 +40,18 @@ namespace JS {
       double jobId() const { return [_v[@"jobId"] doubleValue]; }
       NSString *fromUrl() const  { return _v[@"fromUrl"]; }
       NSString *toFile() const  { return _v[@"toFile"]; }
-      bool background() const  { return _v[@"background"]; }
+      bool background() const  { return [_v[@"background"] boolValue]; }
       double backgroundTimeout() const  { return [_v[@"backgroundTimeout"] doubleValue]; }
-      bool cacheable() const  { return _v[@"cacheable"]; }
+      bool cacheable() const  { return [_v[@"cacheable"] boolValue]; }
       double connectionTimeout() const  { return [_v[@"connectionTimeout"] doubleValue]; }
-      bool discretionary() const  { return _v[@"discretionary"]; }
+      bool discretionary() const  { return [_v[@"discretionary"] boolValue]; }
       id<NSObject>  headers() const  { return _v[@"headers"]; }
       double progressDivider() const  { return [_v[@"progressDivider"] doubleValue]; }
       double progressInterval() const  { return [_v[@"progressInterval"] doubleValue]; }
       double readTimeout() const  { return [_v[@"readTimeout"] doubleValue]; }
-      bool hasBeginCallback() const  { return _v[@"hasBeginCallback"]; }
-      bool hasProgressCallback() const  { return _v[@"hasProgressCallback"]; }
-      bool hasResumableCallback() const  { return _v[@"hasResumableCallback"]; }
+      bool hasBeginCallback() const  { return [_v[@"hasBeginCallback"] boolValue]; }
+      bool hasProgressCallback() const  { return [_v[@"hasProgressCallback"] boolValue]; }
+      bool hasResumableCallback() const  { return [_v[@"hasResumableCallback"] boolValue]; }
 
       NativeDownloadFileOptionsT(NSDictionary *const v) : _v(v) {}
     private:

--- a/ios/ReactNativeFs.mm
+++ b/ios/ReactNativeFs.mm
@@ -553,7 +553,7 @@ RCT_EXPORT_METHOD(downloadFile:(JS::NativeReactNativeFs::NativeDownloadFileOptio
   NSNumber* discretionary = [NSNumber numberWithBool:options.discretionary()];
   params.discretionary = [discretionary boolValue];
   NSNumber* cacheable = [NSNumber numberWithBool:options.cacheable()];
-  params.cacheable = cacheable ? [cacheable boolValue] : YES;
+  params.cacheable = [cacheable boolValue];
   NSNumber* progressInterval= [NSNumber numberWithDouble:options.progressInterval()];
   params.progressInterval = progressInterval;
   NSNumber* progressDivider = [NSNumber numberWithDouble:options.progressDivider()];

--- a/src/index.ts
+++ b/src/index.ts
@@ -173,7 +173,7 @@ export function downloadFile(options: DownloadFileOptionsT): {
     toFile: normalizeFilePath(options.toFile),
     background: !!options.background,
     backgroundTimeout: options.backgroundTimeout || 3600000, // 1 hour
-    cacheable: !!options.cacheable,
+    cacheable: options.cacheable === undefined ? true : options.cacheable,
     connectionTimeout: options.connectionTimeout || 5000,
     discretionary: !!options.discretionary,
     headers: options.headers || {},


### PR DESCRIPTION
Boolean values were not correctly converted from RN to ObjC for downloadFile(), so all values were always true.

The PR fixes the problem, the values specified by the user from RN are now also used in the native iOS part.

The background download mode is no longer started automatically, the “discretionary” flag is no longer automatically set to true.

The “cacheable” flag can now also be set to false by the user.

The explanation of “discretionary” in the readme has been clarified.