### PR TITLE
Correct the type of ctime and mtime in StatResultT. 

### DIFF
--- a/src/NativeReactNativeFs.ts
+++ b/src/NativeReactNativeFs.ts
@@ -140,8 +140,8 @@ export type StatResultT = {
   path: string; // The absolute path to the item
   size: number; // Size in bytes
   mode: number; // UNIX file mode
-  ctime: Date | number; // Created date
-  mtime: Date | number; // Last modified date
+  ctime: Date; // Created date
+  mtime: Date; // Last modified date
 
   // In case of content uri this is the pointed file path,
   // otherwise is the same as path.

--- a/src/index.ts
+++ b/src/index.ts
@@ -560,6 +560,7 @@ export {
   type MkdirOptionsT,
   type ReadDirAssetsResItemT,
   type ReadDirResItemT,
+  type StatResultT,
   type StringMapT,
   type UploadBeginCallbackArgT,
   type UploadFileItemT,


### PR DESCRIPTION
According the [doc](https://github.com/birdofpreyru/react-native-fs/tree/v2.27.1?tab=readme-ov-file#statresultt) and [code](https://github.com/birdofpreyru/react-native-fs/blob/v2.27.1/src/index.ts#L277), the type of `ctime` and `mtime` in `StatResultT` should be `Date` but not `Date | number`.

This pull request is to correct the type. I also exported the `StatResultT` in the same way as how `DownloadResultT` and etc are exported. 