### PR TITLE
fix: make eslint-plugin-ft-flow a devDependency rather than a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
   },
   "dependencies": {
     "buffer": "^6.0.3",
-    "eslint-plugin-ft-flow": "^3.0.11",
     "http-status-codes": "^2.3.0"
   },
   "devDependencies": {
@@ -67,6 +66,7 @@
     "del-cli": "^5.1.0",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-ft-flow": "^3.0.11",
     "eslint-plugin-prettier": "^5.2.1",
     "jest": "^29.7.0",
     "metro-config": "^0.80.9",


### PR DESCRIPTION
`eslint-plugin-ft-flow` was incorrectly added as a dependency instead of devDependency in #60 