### PR TITLE
Add react-native-macos support

### DIFF
--- a/dr-pogodin-react-native-fs.podspec
+++ b/dr-pogodin-react-native-fs.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.license      = package["license"]
   s.authors      = package["author"]
 
-  s.platforms    = { :ios => min_ios_version_supported }
+  s.platforms    = { :ios => min_ios_version_supported, osx: "10.15" }
   s.source       = { :git => "https://github.com/birdofpreyru/react-native-fs.git", :tag => "#{s.version}" }
 
   s.resource_bundles = { 'RNFS_PrivacyInfo' => 'ios/PrivacyInfo.xcprivacy' }

--- a/ios/ReactNativeFs.h
+++ b/ios/ReactNativeFs.h
@@ -3,7 +3,12 @@
 #ifdef RCT_NEW_ARCH_ENABLED
 #import "RNReactNativeFsSpec.h"
 
-@interface ReactNativeFs : RCTEventEmitter <NativeReactNativeFsSpec,UIDocumentPickerDelegate>
+@interface ReactNativeFs : RCTEventEmitter <
+  NativeReactNativeFsSpec
+#if !TARGET_OS_OSX
+  ,UIDocumentPickerDelegate
+#endif
+>
 #else
 #import <optional>
 #import <React/RCTCxxConvert.h>
@@ -141,7 +146,13 @@ namespace JS {
 }
 @end
 
-@interface ReactNativeFs : RCTEventEmitter <RCTBridgeModule,UIDocumentPickerDelegate>
+@interface ReactNativeFs : RCTEventEmitter <
+  RCTBridgeModule
+#if !TARGET_OS_OSX
+  ,UIDocumentPickerDelegate
+#endif
+>
+
 #endif
 
 @property (retain) NSMutableDictionary* downloaders;

--- a/ios/ReactNativeFs.mm
+++ b/ios/ReactNativeFs.mm
@@ -1129,6 +1129,7 @@ RCT_EXPORT_METHOD(touch:(NSString*)filepath
   [[RNFSException NOT_IMPLEMENTED] reject:reject details:@"setReadable()"];
 }
 
+#if !TARGET_OS_OSX
 - (void)documentPicker:(UIDocumentPickerViewController *)picker
 didPickDocumentsAtURLs:(NSArray<NSURL *> *)urls
 {
@@ -1178,6 +1179,7 @@ didPickDocumentsAtURLs:(NSArray<NSURL *> *)urls
   }
   // TODO: Should crash here, as it is a fatal error.
 }
+#endif
 
 RCT_EXPORT_METHOD(
 #ifdef RCT_NEW_ARCH_ENABLED
@@ -1188,6 +1190,7 @@ RCT_EXPORT_METHOD(
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject
 ) {
+# if TARGET_OS_IOS
   // NOTE: We must copy options into a local variable, so that (especially with
   // the new, bridgeless architecture) it is correctly detained by the async
   // block below, not crushing the app.
@@ -1250,6 +1253,9 @@ RCT_EXPORT_METHOD(
       [[RNFSException fromException:e] reject:reject];
     }
   });
+# else
+  [[RNFSException NOT_IMPLEMENTED] reject:reject details:@"pickFile()"];
+# endif
 }
 
 /**


### PR DESCRIPTION
Hi. I'm opening this PR to see if there is interest.

As seen by the [old lib](https://github.com/itinance/react-native-fs/commit/adb09773b67c93b7da698a0fb22fdf442c2a16fc), react-native-macos should really be compatible just as-is with the iOS code as there's little to no difference between iOS and macOS regarding file system matters (in my experience at least).

The UI document picker however is different between the operating systems, so I've disabled `pickFile()` for react-native-macos. Every API has *not* been tested. But for example `RNFS.LibraryDirectoryPath` works without any issues.

Closes #40.

Cheers!