### PR TITLE
Reject stopped download if resumable is not set

### DIFF
--- a/README.md
+++ b/README.md
@@ -1095,9 +1095,10 @@ function stopDownload(jobId: number): void;
 ```
 **VERIFIED:** Android, iOS.
 
-Aborts a file download job. The partial file will remain on the filesystem,
-and the promise returned from the aborted [downloadFile()] call will reject
-with an error.
+Aborts a file download job. The partial file will remain on the filesystem.
+If resume is not supported (Android), or if the `resumable` optional argument
+is not set when calling [downloadFile()], the promise returned from the aborted
+[downloadFile()] call will reject with an error.
 - `jobId` &mdash; **number** &mdash; Download job ID (see [downloadFile()]).
 
 ### stopUpload()

--- a/ios/Downloader.mm
+++ b/ios/Downloader.mm
@@ -164,11 +164,9 @@
 {
   if (_task.state == NSURLSessionTaskStateRunning) {
     [_task cancelByProducingResumeData:^(NSData * _Nullable resumeData) {
-        if (resumeData != nil) {
+        if (resumeData != nil && self->_params.resumableCallback) {
             self.resumeData = resumeData;
-            if (self->_params.resumableCallback) {
-                self->_params.resumableCallback();
-            }
+            self->_params.resumableCallback();
         } else {
             NSError *error = [NSError errorWithDomain:@"RNFS"
                                                  code:0 //used to pass an NSString @"Aborted" here, but it needs an NSInteger


### PR DESCRIPTION
This is a way to solve the problem described in #72, while being reasonably backward compatible: If `resumable` is not set when calling `downloadFile`, there is presumably no expectation that the download could be resumed, so the download should be treated as permanently cancelled.

Resolves #72