### PR TITLE
fix(type-exports): so that function types can be properly inferred

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "source": "./src/index.ts",
   "main": "./lib/commonjs/index.js",
   "module": "./lib/module/index.js",
+  "types": "./lib/typescript/module/src",
   "exports": {
     ".": {
       "import": {


### PR DESCRIPTION
This should address build/inspection issues referenced in #70