### PR TITLE
Fix: Resolve Mismatch Arguments in `ReactNativeFsPackage.kt` (Issue #106)

### DIFF
--- a/android/src/main/java/com/drpogodin/reactnativefs/ReactNativeFsPackage.kt
+++ b/android/src/main/java/com/drpogodin/reactnativefs/ReactNativeFsPackage.kt
@@ -24,6 +24,8 @@ class ReactNativeFsPackage : BaseReactPackage() {
         ReactNativeFsModule.NAME,
         canOverrideExistingModule = false,  // canOverrideExistingModule
         needsEagerInit = false,  // needsEagerInit
+        hasConstants = true,   // Deprecated: This property is unused and it's planning to be removed in a future version of
+        React Native.
         isCxxModule = false,  // isCxxModule
         isTurboModule = true // isTurboModule
       )

--- a/android/src/main/java/com/drpogodin/reactnativefs/ReactNativeFsPackage.kt
+++ b/android/src/main/java/com/drpogodin/reactnativefs/ReactNativeFsPackage.kt
@@ -24,8 +24,7 @@ class ReactNativeFsPackage : BaseReactPackage() {
         ReactNativeFsModule.NAME,
         canOverrideExistingModule = false,  // canOverrideExistingModule
         needsEagerInit = false,  // needsEagerInit
-        hasConstants = true,   // Deprecated: This property is unused and it's planning to be removed in a future version of
-        React Native.
+        hasConstants = true,   // Deprecated: This property is unused and it's planning to be removed in a future version of React Native.
         isCxxModule = false,  // isCxxModule
         isTurboModule = true // isTurboModule
       )


### PR DESCRIPTION
# Fix: Resolve Mismatch Arguments in `ReactNativeFsPackage.kt` (Issue #106)

## Description  
This PR addresses **Issue #106**, where the build fails with an exception during the `:dr.pogodin_react-native-fs:compileReleaseKotlin` task. The failure occurred due to mismatched arguments in the `ReactModuleInfo` constructor. The `hasConstants` parameter is unused and it's planning to be removed in a future version of React Native. but still required, causing the build to break.

## Changes  
- Corrected the argument list in `ReactNativeFsPackage.kt` to match the updated `ReactModuleInfo` constructor.  
- Added comments to clarify the expected argument order for future reference.  

## Testing  
- Verified the fix by successfully building the app in release mode.  
- Tested with Expo in both development and production builds.  

## Impact  
This fix restores the build process, preventing compilation failures and allowing seamless bundling in both development and release environments.

Closes: #106  
