### PR TITLE
fix(deps): remove unnecessary react-native-windows dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,8 +51,7 @@
   },
   "dependencies": {
     "buffer": "^6.0.3",
-    "http-status-codes": "^2.3.0",
-    "react-native-windows": "0.80.0-preview.2"
+    "http-status-codes": "^2.3.0"
   },
   "devDependencies": {
     "@eslint/compat": "^1.3.2",
@@ -73,6 +72,7 @@
     "react": "19.1.0",
     "react-native": "0.81.0",
     "react-native-builder-bob": "^0.40.13",
+    "react-native-windows": "0.80.0-preview.2",
     "typescript": "^5.9.2"
   },
   "peerDependencies": {


### PR DESCRIPTION
react-native-fs does not require react-native-windows to function. Including it as a dependency causes unnecessary installation of react-native-windows in projects that do not use it.

This commit removes react-native-windows from dependencies and moves it to devDependencies, so it will only be used for development and not installed in consumer projects.

Developers who need Windows support can explicitly add react-native-windows as a dependency in their own projects.