### PR TITLE
Added response headers and body for downloadFile error responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,7 +413,7 @@ const DocumentDirectoryPath: string;
 
 The absolute path to the document directory.
 
-**IMPORTANT**: `DocumentDirectoryPath` (iOS) will include an ID in the path that changes each build e.g `...Application/BCE32988-4C51-483B-892B-16671E3771C2/Documents`. 
+**IMPORTANT**: `DocumentDirectoryPath` (iOS) will include an ID in the path that changes each build e.g `...Application/BCE32988-4C51-483B-892B-16671E3771C2/Documents`.
 
 Use relative paths and resolve the full path at runtime to avoid files not being found on new builds.
 
@@ -886,7 +886,7 @@ function pickFile(options?: PickFileOptionsT): Promise<string[]>;
 Prompts the user to select file(s) using a platform-provided file picker UI,
 which also allows to access files outside the app sandbox.
 
-**BEWARE:** On **windows** the options differ from the other platform since the 
+**BEWARE:** On **windows** the options differ from the other platform since the
 native file piper doesn't support `mimeTypes` but `fileExtensions` and different
 picker types like `singleFile`, `multipleFIle` and `folder`. For more information
 see [PickFileOptionsT].
@@ -1191,7 +1191,7 @@ in this library fork.
 ```ts
 function write(filepath: string, contents: string, position?: number, encoding?: EncodingT): Promise<void>;
 ```
-**VERIFIED:** Android, iOS, macOS, Windows 
+**VERIFIED:** Android, iOS, macOS, Windows
 
 Writes content to a file at the given random access position.
 
@@ -1313,7 +1313,7 @@ The type of options argument of [downloadFile()].
   argument of [DownloadProgressCallbackResultT] type.
 
 - `resumable` &mdash; **() => void** &mdash; Optional. iOS-only. If provided,
-  it is invoked when the download has stopped and and can be resumed using [resumeDownload()]. 
+  it is invoked when the download has stopped and and can be resumed using [resumeDownload()].
 
 - `connectionTimeout` &mdash; **number** &mdash; Optional. Only supported on
   Android yet.
@@ -1347,6 +1347,8 @@ type DownloadResultT = {
   jobId: number;
   statusCode: number;
   bytesWritten: number;
+  headers: StringMapT; // iOS and Android only
+  body?: string; // iOS and Android only
 };
 ```
 Return type of [downloadFile()].
@@ -1355,6 +1357,9 @@ Return type of [downloadFile()].
 - `statusCode` &mdash; **number** &mdash; The HTTP status code.
 - `bytesWritten` &mdash; **number** &mdash; The number of bytes written to
   the file.
+- `headers` &mdash; [StringMapT] &mdash; The HTTP response headers from
+  the server.
+- `body` &mdash; **string** &mdash; The HTTP response body only for not in the range 200-299 status codes
 
 ### EncodingT
 [EncodingT]: #encodingt
@@ -1431,10 +1436,10 @@ Optional parameters for [pickFile()] function.
   of files user is allowed to select. Defaults to `['*/*']` allowing to select
   any file.
 - `pickerType` &mdash; **'singleFile' | 'multipleFiles' | 'folder'** &mdash;  *[Windows]* Optional.
-   The type of objects to pick can be either a single file, multiple files or one folder. 
+   The type of objects to pick can be either a single file, multiple files or one folder.
    - Multiple folders are not supported by windows.
    - Defaults to `'singleFile'` */
-- `fileExtensions` &mdash; **FileExtension[]** &mdash; *[Windows]* Optional, The file extensions to pick from. 
+- `fileExtensions` &mdash; **FileExtension[]** &mdash; *[Windows]* Optional, The file extensions to pick from.
    - Only applies to `pickerType !== 'folder'`
    - Defaults to `[]` (all file extensions) */
    - `FileExtension = ´.${string}´` - e.g `'.bmp'`, `'.mp3'`

--- a/android/src/main/java/com/drpogodin/reactnativefs/DownloadParams.kt
+++ b/android/src/main/java/com/drpogodin/reactnativefs/DownloadParams.kt
@@ -10,7 +10,7 @@ class DownloadParams {
     }
 
     interface OnDownloadBegin {
-        fun onDownloadBegin(statusCode: Int, contentLength: Long, headers: Map<String, String?>?)
+        fun onDownloadBegin(statusCode: Int, contentLength: Long, headers: ReadableMap)
     }
 
     interface OnDownloadProgress {

--- a/android/src/main/java/com/drpogodin/reactnativefs/DownloadResult.kt
+++ b/android/src/main/java/com/drpogodin/reactnativefs/DownloadResult.kt
@@ -1,10 +1,16 @@
 package com.drpogodin.reactnativefs
 
+import com.facebook.react.bridge.WritableMap
+
 class DownloadResult {
     @JvmField
     var statusCode = 0
     @JvmField
     var bytesWritten: Long = 0
+    @JvmField
+    var headers: WritableMap? = null
+    @JvmField
+    var body: String? = null
     @JvmField
     var exception: Exception? = null
 }

--- a/android/src/main/java/com/drpogodin/reactnativefs/ReactNativeFsModule.kt
+++ b/android/src/main/java/com/drpogodin/reactnativefs/ReactNativeFsModule.kt
@@ -263,6 +263,8 @@ class ReactNativeFsModule(reactContext: ReactApplicationContext) :
                         infoMap.putInt("jobId", jobId)
                         infoMap.putInt("statusCode", res.statusCode)
                         infoMap.putDouble("bytesWritten", res.bytesWritten.toDouble())
+                        infoMap.putMap("headers", res.headers)
+                        infoMap.putString("body", res.body)
                         promise.resolve(infoMap)
                     } else {
                         reject(promise, options.getString("toFile"), res.exception)
@@ -271,16 +273,12 @@ class ReactNativeFsModule(reactContext: ReactApplicationContext) :
             }
             if (hasBeginCallback) {
                 params.onDownloadBegin = object : OnDownloadBegin {
-                    override fun onDownloadBegin(statusCode: Int, contentLength: Long, headers: Map<String, String?>?) {
-                        val headersMap = Arguments.createMap()
-                        for ((key, value) in headers!!) {
-                            headersMap.putString(key, value)
-                        }
+                    override fun onDownloadBegin(statusCode: Int, contentLength: Long, headers: ReadableMap) {
                         val data = Arguments.createMap()
                         data.putInt("jobId", jobId)
                         data.putInt("statusCode", statusCode)
                         data.putDouble("contentLength", contentLength.toDouble())
-                        data.putMap("headers", headersMap)
+                        data.putMap("headers", headers)
                         sendEvent("DownloadBegin", data)
                     }
                 }

--- a/ios/Downloader.h
+++ b/ios/Downloader.h
@@ -1,6 +1,6 @@
 #import <Foundation/Foundation.h>
 
-typedef void (^DownloadCompleteCallback)(NSNumber*, NSNumber*);
+typedef void (^DownloadCompleteCallback)(NSNumber*, NSNumber*, NSDictionary*, NSString*);
 typedef void (^ErrorCallback)(NSError*);
 typedef void (^BeginCallback)(NSNumber*, NSNumber*, NSDictionary*);
 typedef void (^ProgressCallback)(NSNumber*, NSNumber*);

--- a/ios/ReactNativeFs.mm
+++ b/ios/ReactNativeFs.mm
@@ -608,7 +608,7 @@ RCT_EXPORT_METHOD(downloadFile:(JS::NativeReactNativeFs::NativeDownloadFileOptio
 
   __block BOOL callbackFired = NO;
 
-  params.completeCallback = ^(NSNumber* statusCode, NSNumber* bytesWritten) {
+  params.completeCallback = ^(NSNumber* statusCode, NSNumber* bytesWritten, NSDictionary* headers, NSString* body) {
     if (callbackFired) {
       return;
     }
@@ -620,6 +620,12 @@ RCT_EXPORT_METHOD(downloadFile:(JS::NativeReactNativeFs::NativeDownloadFileOptio
     }
     if (bytesWritten) {
       [result setObject:bytesWritten forKey: @"bytesWritten"];
+    }
+    if (headers) {
+      [result setObject:headers forKey: @"headers"];
+    }
+    if (body) {
+      [result setObject:body forKey: @"body"];
     }
     return resolve(result);
   };
@@ -990,7 +996,7 @@ RCT_EXPORT_METHOD(copyAssetsVideoIOS: (NSString *) imageUri
       NSURL *url = [(AVURLAsset *)asset URL];
       NSLog(@"Final URL %@",url);
       BOOL writeResult = false;
-        
+
       if (@available(iOS 9.0, *)) {
           NSURL *destinationUrl = [NSURL fileURLWithPath:destination relativeToURL:nil];
           writeResult = [[NSFileManager defaultManager] copyItemAtURL:url toURL:destinationUrl error:&error];
@@ -998,7 +1004,7 @@ RCT_EXPORT_METHOD(copyAssetsVideoIOS: (NSString *) imageUri
           NSData *videoData = [NSData dataWithContentsOfURL:url];
           writeResult = [videoData writeToFile:destination options:NSDataWritingAtomic error:&error];
       }
-        
+
       if(writeResult) {
         NSLog(@"video success");
       }
@@ -1088,15 +1094,15 @@ RCT_EXPORT_METHOD(touch:(NSString*)filepath
   return [self constantsToExport];
 }
 
-- (void)copyFileAssets:(NSString *)from into:(NSString *)into resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject { 
+- (void)copyFileAssets:(NSString *)from into:(NSString *)into resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject {
   [[RNFSException NOT_IMPLEMENTED] reject:reject details:@"copyFileAssets()"];
 }
 
-- (void)copyFileRes:(NSString *)from into:(NSString *)into resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject { 
+- (void)copyFileRes:(NSString *)from into:(NSString *)into resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject {
   [[RNFSException NOT_IMPLEMENTED] reject:reject details:@"copyFileRes()"];
 }
 
-- (void)copyFolder:(NSString *)from into:(NSString *)into resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject { 
+- (void)copyFolder:(NSString *)from into:(NSString *)into resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject {
   [[RNFSException NOT_IMPLEMENTED] reject:reject details:@"copyFolder()"];
 }
 
@@ -1104,23 +1110,23 @@ RCT_EXPORT_METHOD(touch:(NSString*)filepath
   [[RNFSException NOT_IMPLEMENTED] reject:reject details:@"existsAssets()"];
 }
 
-- (void)existsRes:(NSString *)path resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject { 
+- (void)existsRes:(NSString *)path resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject {
   [[RNFSException NOT_IMPLEMENTED] reject:reject details:@"existsRes()"];
 }
 
-- (void)getAllExternalFilesDirs:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject { 
+- (void)getAllExternalFilesDirs:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject {
   [[RNFSException NOT_IMPLEMENTED] reject:reject details:@"getAllExternalFilesDirs()"];
 }
 
-- (void)readFileAssets:(NSString *)path resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject { 
+- (void)readFileAssets:(NSString *)path resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject {
   [[RNFSException NOT_IMPLEMENTED] reject:reject details:@"readFileAssets()"];
 }
 
-- (void)readFileRes:(NSString *)path resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject { 
+- (void)readFileRes:(NSString *)path resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject {
   [[RNFSException NOT_IMPLEMENTED] reject:reject details:@"readFileRes()"];
 }
 
-- (void)scanFile:(NSString *)path resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject { 
+- (void)scanFile:(NSString *)path resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject {
   [[RNFSException NOT_IMPLEMENTED] reject:reject details:@"scanFile()"];
 }
 

--- a/src/NativeReactNativeFs.ts
+++ b/src/NativeReactNativeFs.ts
@@ -88,6 +88,8 @@ export type DownloadResultT = {
   jobId: number; // The download job ID, required if one wishes to cancel the download. See `stopDownload`.
   statusCode: number; // The HTTP status code
   bytesWritten: number; // The number of bytes written to the file
+  headers?: StringMapT; // The HTTP response headers from the server
+  body?: string; // The HTTP response body
 };
 
 export type FileOptionsT = {


### PR DESCRIPTION
RNFS.downloadFile()

Android, iOS 

## Summary

If you need to get error message from server on error response, now there is no body and headers in the response, this changes adds body and headers to response if there is status code is not in 200..299.

## Changes

- Added response headers and body for downloadFile error responses
- Call begin callback in downloadFile on android even if status code not in 200..299 for consistency with iOS

***The code may not be optimal and may need refactoring.**

Successfully tested on emulators (iOS 26, Android api 36)

Related to #56