### PR TITLE
fix(ios): add ios.modulesProvider to codegenConfig so ReactNativeFs resolves on Old Architecture

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,6 +103,11 @@
     "android": {
       "javaPackageName": "com.drpogodin.reactnativefs"
     },
+    "ios": {
+      "modulesProvider": {
+        "ReactNativeFs": "ReactNativeFs"
+      }
+    },
     "windows": {
       "namespace": "ReactNativeFsCodegen",
       "outputDirectory": "windows/ReactNativeFs/codegen",


### PR DESCRIPTION
## Problem

On apps running the Old (Legacy/Bridge) Architecture, `TurboModuleRegistry.getEnforcing('ReactNativeFs')`
throws:

    Invariant Violation: TurboModuleRegistry.getEnforcing(...): 'ReactNativeFs'
    could not be found. Verify that a module by this name is registered in
    the native binary.

`ReactNativeFs.mm` only implements the Codegen-generated `NativeReactNativeFsSpec`
protocol (no `RCT_EXPORT_MODULE()`), so it's never registered in the classic
bridge module list. It's only discoverable through `RCTTurboModuleManager`,
which in turn needs Codegen's `RCTModuleProviders.mm` to map the JS module
name `ReactNativeFs` to its native class — and that mapping is only generated
when `codegenConfig.ios.modulesProvider` is present in `package.json`.

This field is missing today, so the library only works out-of-the-box on the
New Architecture, even though `NativeReactNativeFsSpecBase`/`ReactNativeFs.mm`
are otherwise written to support both.

## Fix

Add the standard RN 0.79+ `ios.modulesProvider` entry to `codegenConfig`,
mirroring the existing `android`/`windows` entries:

```json
"codegenConfig": {
  ...
  "ios": {
    "modulesProvider": {
      "ReactNativeFs": "ReactNativeFs"
    }
  },
  ...
}