### PR TITLE
fix: isolate upload callbacks and always release subscriptions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -337,24 +337,9 @@ export function uploadFiles(options: UploadFileOptionsT): {
     throw new Error('uploadFiles: Invalid value for property `method`');
   }
 
-  if (options.begin) {
-    subscriptions.push(RNFS.onUploadBegin(options.begin));
-
-    // TODO: Deprecated, will be removed in a future release.
-  } else if (options.beginCallback) {
-    subscriptions.push(RNFS.onUploadBegin(options.beginCallback));
-  }
-
-  if (options.progress) {
-    subscriptions.push(RNFS.onUploadProgress(options.progress));
-
-    // TODO: Deprecated, will be removed in a future release.
-  } else if (options.progressCallback) {
-    subscriptions.push(RNFS.onUploadProgress(options.progressCallback));
-  }
-
   const files = options.files.map(item => ({
     ...item,
+    filepath: normalizeFilePath(item.filepath),
     name: item.name ?? item.filename,
   }));
 
@@ -374,19 +359,44 @@ export function uploadFiles(options: UploadFileOptionsT): {
       options.progressCallback instanceof Function,
   };
 
+  const begin = options.begin || options.beginCallback;
+  const progress = options.progress || options.progressCallback;
+
   return {
     jobId,
-    promise: RNFS.uploadFiles(nativeOptions).then((res: UploadResultT) => {
-      subscriptions.forEach(sub => sub.remove());
-
-      if (res.statusCode >= 400) {
-        const error = Error(getReasonPhrase(res.statusCode));
-        (error as any).result = res;
-        throw error;
+    promise: (async () => {
+      try {
+        if (begin) {
+          subscriptions.push(
+            RNFS.onUploadBegin(res => {
+              if (res.jobId === jobId) begin(res);
+            }),
+          );
+        }
+        if (progress) {
+          subscriptions.push(
+            RNFS.onUploadProgress(res => {
+              if (res.jobId === jobId) progress(res);
+            }),
+          );
+        }
+        const res = await RNFS.uploadFiles(nativeOptions);
+        if (res.statusCode >= 400) {
+          let message = `HTTP ${res.statusCode}`;
+          try {
+            message = getReasonPhrase(res.statusCode);
+          } catch {
+            // Keep the response available for non-standard HTTP status codes.
+          }
+          const error = Error(message);
+          (error as any).result = res;
+          throw error;
+        }
+        return res;
+      } finally {
+        subscriptions.forEach(sub => sub.remove());
       }
-
-      return res;
-    }),
+    })(),
   };
 }
 


### PR DESCRIPTION
## Fixes

Filter current and deprecated upload callbacks by jobId; clean up on native rejection, synchronous native failure and partial listener registration; normalize file:// upload paths without mutating caller objects; retain response data for non-standard HTTP errors.

## Compatibility / breaking changes

No TypeScript signature changes. Upload callbacks no longer receive other jobs. Native setup failures now reject the returned promise instead of escaping synchronously. Unknown HTTP status errors retain error.result and use an HTTP <status> fallback message.

## Verification

Actual transpiled entrypoint with event/native doubles: concurrent and deprecated callbacks, rejection, setup/registration failures, invalid files, frozen file URI options, and HTTP 500/599. Baseline cross-job calls/leaks and missing HTTP599 response reproduce; fixed cases pass.

## Shared verification

`yarn test` (ESLint + TypeScript), `yarn prepare` (module/declarations), and `git diff --check` pass for the combined review checkout. React Doctor reports 100/100 for the changed JS scope. Native checks are described above; no physical-device, signed-release or production verification is claimed. No checked-in test/spec files were changed. Isolated diagnostics were run outside the repository. Consumer verification at immutable combined pin eb4ee671c47acc73ce4e84f2d0e19027eb476ff0 (RN 0.87.1): immutable install and lint, both Android Debug flavors, both iOS Simulator Debug schemes, four release-mode Metro bundles, 13 production web builds and four browser-extension builds pass. All 72 installed non-metadata files match reviewed source/rebuilt artifacts. Windows SDK/runtime remains unverified.
