### PR TITLE
fix(android): stream multipart uploads with accurate byte counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Mac (Catalyst), and Windows platforms.
       [Media Scanner](https://developer.android.com/reference/android/media/MediaScannerConnection).
     - [stat()] &mdash; Returns info on a file system item.
     - [stopDownload()] &mdash; Aborts a file download job.
-    - [stopUpload()] &mdash; (iOS only) Aborts file upload job.
+    - [stopUpload()] &mdash; (Android and iOS) Aborts file upload job.
     - [touch()] &mdash; Alters creation and modification timestamps of the given file.
     - [unlink()] &mdash; Unlinks (removes) a file or directory with files.
   and return its contents.
@@ -1156,12 +1156,12 @@ is not set when calling [downloadFile()], the promise returned from the aborted
 ```ts
 function stopUpload(jobId: number): void;
 ```
-**VERIFIED:** iOS. **NOT SUPPORTED**: Android, Windows.
+**SUPPORTED:** Android, iOS. **NOT SUPPORTED**: Windows.
 
-iOS only. Abort the current upload job with given ID.
+Abort the current upload job with given ID.
 
-**NOTE:** Unlike [stopDownload()] it does not cause the pending upload promise
-to reject. Perhaps, we'll change it in future to behave similarly.
+On Android, cancellation rejects the pending upload promise. Handle that
+rejection like other upload failures. The iOS cancellation behavior is unchanged.
 
 - `jobId` &mdash; **number** &mdash; Upload job ID.
 

--- a/android/src/main/java/com/drpogodin/reactnativefs/ReactNativeFsModule.kt
+++ b/android/src/main/java/com/drpogodin/reactnativefs/ReactNativeFsModule.kt
@@ -739,11 +739,11 @@ class ReactNativeFsModule(reactContext: ReactApplicationContext) :
             }
             if (hasProgressCallback) {
                 params.onUploadProgress = object : UploadParams.OnUploadProgress {
-                    override fun onUploadProgress(totalBytesExpectedToSend: Int, totalBytesSent: Int) {
+                    override fun onUploadProgress(totalBytesExpectedToSend: Long, totalBytesSent: Long) {
                         val data = Arguments.createMap().apply {
                             putInt("jobId", jobId)
-                            putInt("totalBytesExpectedToSend", totalBytesExpectedToSend)
-                            putInt("totalBytesSent", totalBytesSent)
+                            putDouble("totalBytesExpectedToSend", totalBytesExpectedToSend.toDouble())
+                            putDouble("totalBytesSent", totalBytesSent.toDouble())
                         }
                         emitOnUploadProgress(data)
                     }

--- a/android/src/main/java/com/drpogodin/reactnativefs/UploadParams.kt
+++ b/android/src/main/java/com/drpogodin/reactnativefs/UploadParams.kt
@@ -9,7 +9,7 @@ class UploadParams {
     }
 
     interface OnUploadProgress {
-        fun onUploadProgress(totalBytesExpectedToSend: Int, totalBytesSent: Int)
+        fun onUploadProgress(totalBytesExpectedToSend: Long, totalBytesSent: Long)
     }
 
     interface OnUploadBegin {

--- a/android/src/main/java/com/drpogodin/reactnativefs/Uploader.kt
+++ b/android/src/main/java/com/drpogodin/reactnativefs/Uploader.kt
@@ -3,204 +3,134 @@ package com.drpogodin.reactnativefs
 import android.os.AsyncTask
 import android.webkit.MimeTypeMap
 import com.facebook.react.bridge.Arguments
-import java.io.BufferedInputStream
-import java.io.BufferedReader
-import java.io.DataOutputStream
 import java.io.File
 import java.io.FileInputStream
-import java.io.InputStreamReader
+import java.io.IOException
 import java.net.HttpURLConnection
-import java.nio.channels.Channels
 import java.util.Locale
-import java.util.concurrent.atomic.AtomicBoolean
-import kotlin.math.ceil
 import java.util.UUID
+import java.util.concurrent.atomic.AtomicBoolean
 
 class Uploader : AsyncTask<UploadParams?, IntArray?, UploadResult>() {
-    private var mParams: UploadParams? = null
-    private var res: UploadResult? = null
     private val mAbort = AtomicBoolean(false)
+    @Volatile private var connection: HttpURLConnection? = null
 
     @Deprecated("Deprecated in Java")
     override fun doInBackground(vararg uploadParams: UploadParams?): UploadResult {
-        mParams = uploadParams[0]
-        res = UploadResult()
+        val params = uploadParams[0]!!
+        val result = UploadResult()
         Thread {
             try {
-                upload(mParams)
-                mParams!!.onUploadComplete?.onUploadComplete(res!!)
+                upload(params, result)
             } catch (e: Exception) {
-                res!!.exception = e
-                mParams!!.onUploadComplete?.onUploadComplete(res!!)
+                result.exception = e
             }
+            params.onUploadComplete?.onUploadComplete(result)
         }.start()
-        return res!!
+        return result
     }
 
     @Throws(Exception::class)
-    private fun upload(params: UploadParams?) {
-        var connection: HttpURLConnection? = null
-        var request: DataOutputStream? = null
-        val crlf = "\r\n"
-        val twoHyphens = "--"
+    private fun upload(params: UploadParams, result: UploadResult) {
+        val crlf = "\r\n".toByteArray(Charsets.UTF_8)
         val boundary = "----" + UUID.randomUUID().toString().replace("-", "")
-        val tail = twoHyphens + boundary + twoHyphens + crlf
-        var metaData = ""
-        var stringData = ""
-        val fileHeader: Array<String?>
-        val statusCode: Int
-        var byteSentTotal: Int
-        var fileCount = 0
-        var totalFileLength: Long = 0
-        var responseStream: BufferedInputStream? = null
-        var responseStreamReader: BufferedReader? = null
-        var name: String
-        var filename: String
-        var filetype: String
+        val binary = params.binaryStreamOnly
+        val files = params.files!!.map { File(it.getString("filepath")!!) }
+        val fields = buildString {
+            if (!binary) {
+                val keys = params.fields!!.keySetIterator()
+                while (keys.hasNextKey()) {
+                    val key = keys.nextKey()
+                    append("--$boundary\r\nContent-Disposition: form-data; name=\"$key\"\r\n\r\n")
+                    append(params.fields!!.getString(key))
+                    append("\r\n")
+                }
+            }
+        }.toByteArray(Charsets.UTF_8)
+        val headers = params.files!!.mapIndexed { index, file ->
+            if (binary) byteArrayOf()
+            else {
+                val name = file.getString("name")
+                val filename = file.getString("filename")
+                val filetype = file.getString("filetype") ?: getMimeType(file.getString("filepath"))
+                ("--$boundary\r\nContent-Disposition: form-data; name=\"$name\"; filename=\"$filename\"\r\n" +
+                    "Content-Type: $filetype\r\nContent-length: ${files[index].length()}\r\n\r\n")
+                    .toByteArray(Charsets.UTF_8)
+            }
+        }
+        val tail = if (binary) byteArrayOf() else "--$boundary--\r\n".toByteArray(Charsets.UTF_8)
+        val requestLength = files.sumOf { it.length() } + fields.size + tail.size +
+            headers.sumOf { it.size.toLong() } + if (binary) 0 else files.size.toLong() * crlf.size
+        val current = params.src!!.openConnection() as HttpURLConnection
+        connection = current
         try {
-          val files: Array<Any> = params!!.files!!.toTypedArray()
-          val binaryStreamOnly = params.binaryStreamOnly
-          connection = params.src!!.openConnection() as HttpURLConnection
-          connection.doOutput = true
-          val headerIterator = params.headers!!.keySetIterator()
-          connection.requestMethod = params.method
-          if (!binaryStreamOnly) {
-            connection.setRequestProperty("Content-Type", "multipart/form-data;boundary=$boundary")
-          }
-          while (headerIterator.hasNextKey()) {
-            val key = headerIterator.nextKey()
-            val value = params.headers!!.getString(key)
-            connection.setRequestProperty(key, value)
-          }
-          val fieldsIterator = params.fields!!.keySetIterator()
-          while (fieldsIterator.hasNextKey()) {
-            val key = fieldsIterator.nextKey()
-            val value = params.fields!!.getString(key)
-            metaData += twoHyphens + boundary + crlf + "Content-Disposition: form-data; name=\"" + key + "\"" + crlf + crlf + value + crlf
-          }
-          stringData += metaData
-          fileHeader = arrayOfNulls(files.size)
-          for (map in params.files!!) {
-            name = map.getString("name")!!
-            filename = map.getString("filename")!!
-            filetype = map.getString("filetype") ?: getMimeType(map.getString("filepath"))
-            val file = File(map.getString("filepath")!!)
-            val fileLength = file.length()
-            totalFileLength += fileLength
-            if (!binaryStreamOnly) {
-              val fileHeaderType = twoHyphens + boundary + crlf +
-                "Content-Disposition: form-data; name=\"" + name + "\"; filename=\"" + filename + "\"" + crlf +
-                "Content-Type: " + filetype + crlf
-              if (files.size - 1 == fileCount) {
-                totalFileLength += tail.toByteArray().size
-              }
-              val fileLengthHeader = "Content-length: $fileLength$crlf"
-              fileHeader[fileCount] = fileHeaderType + fileLengthHeader + crlf
-              stringData += fileHeaderType + fileLengthHeader + crlf
+            checkNotAborted()
+            current.doOutput = true
+            current.requestMethod = params.method
+            if (!binary) current.setRequestProperty("Content-Type", "multipart/form-data;boundary=$boundary")
+            val keys = params.headers!!.keySetIterator()
+            while (keys.hasNextKey()) {
+                val key = keys.nextKey()
+                current.setRequestProperty(key, params.headers!!.getString(key))
             }
-            fileCount++
-          }
-          fileCount = 0
-          mParams!!.onUploadBegin?.onUploadBegin()
-          if (!binaryStreamOnly) {
-            var requestLength = totalFileLength
-            requestLength += stringData.toByteArray().size + files.size * crlf.toByteArray().size
-            connection.setRequestProperty("Content-length", "" + requestLength.toInt())
-            connection.setFixedLengthStreamingMode(requestLength.toInt())
-          } else {
-            // Stream the raw body straight from disk. Without a streaming mode,
-            // HttpURLConnection buffers the entire request in memory to compute
-            // Content-Length, which OOMs on large files. The long overload also
-            // supports files larger than 2GB.
-            connection.setFixedLengthStreamingMode(totalFileLength)
-          }
-          connection.connect()
-          request = DataOutputStream(connection.outputStream)
-          val requestChannel = Channels.newChannel(request)
-          if (!binaryStreamOnly) {
-            request.writeBytes(metaData)
-          }
-          byteSentTotal = 0
-          for (map in params.files!!) {
-            if (!binaryStreamOnly) {
-              request.writeBytes(fileHeader[fileCount])
+            current.setFixedLengthStreamingMode(requestLength)
+            params.onUploadBegin?.onUploadBegin()
+            checkNotAborted()
+            current.outputStream.use { output ->
+                var sent = 0L
+                fun write(bytes: ByteArray, count: Int = bytes.size) {
+                    checkNotAborted()
+                    output.write(bytes, 0, count)
+                    sent += count
+                }
+                write(fields)
+                val buffer = ByteArray(64 * 1024)
+                files.forEachIndexed { index, file ->
+                    write(headers[index])
+                    FileInputStream(file).use { input ->
+                        var count: Int
+                        while (input.read(buffer).also { count = it } != -1) {
+                            write(buffer, count)
+                            params.onUploadProgress?.onUploadProgress(requestLength, sent)
+                        }
+                    }
+                    if (!binary) write(crlf)
+                }
+                write(tail)
+                output.flush()
+                params.onUploadProgress?.onUploadProgress(requestLength, sent)
             }
-            val file = File(map.getString("filepath")!!)
-            val fileLength = file.length()
-            val bufferSize = ceil((fileLength / 100f).toDouble()).toLong()
-            var bytesRead: Long = 0
-            val fileStream = FileInputStream(file)
-            val fileChannel = fileStream.channel
-            while (bytesRead < fileLength) {
-              val transferredBytes = fileChannel.transferTo(bytesRead, bufferSize, requestChannel)
-              bytesRead += transferredBytes
-              byteSentTotal += transferredBytes.toInt()
-              mParams!!.onUploadProgress?.onUploadProgress(totalFileLength.toInt(), byteSentTotal)
+            checkNotAborted()
+            result.statusCode = current.responseCode
+            val responseHeaders = Arguments.createMap()
+            for ((key, values) in current.headerFields) {
+                if (key != null && values.isNotEmpty()) responseHeaders.putString(key, values[0])
             }
-            if (!binaryStreamOnly) {
-              request.writeBytes(crlf)
-            }
-            fileCount++
-            fileStream.close()
-          }
-          if (!binaryStreamOnly) {
-            request.writeBytes(tail)
-          }
-          request.flush()
-          request.close()
-          responseStream = if (connection.errorStream != null) {
-            BufferedInputStream(connection.errorStream)
-          } else {
-            BufferedInputStream(connection.inputStream)
-          }
-          responseStreamReader = BufferedReader(InputStreamReader(responseStream))
-          val responseHeaders = Arguments.createMap()
-          val map = connection.headerFields
-          for ((key, value) in map) {
-            // NOTE: Although the type of key is evaluated as non-nullable by the compiler,
-            // somehow it may become `null` after the upgrade to RN@0.75, thus this guard for now.
-            if (key !== null) {
-              val count = 0
-              responseHeaders.putString(key, value[count])
-            }
-          }
-          val stringBuilder = StringBuilder()
-          var line: String?
-          while (responseStreamReader.readLine().also { line = it } != null) {
-            stringBuilder.append(line).append("\n")
-          }
-          val response = stringBuilder.toString()
-          statusCode = connection.responseCode
-          res!!.headers = responseHeaders
-          res!!.body = response
-          res!!.statusCode = statusCode
-        } catch (e: Exception) {
-          e.printStackTrace()
-          throw e
+            result.headers = responseHeaders
+            val response = if (result.statusCode >= 400) current.errorStream else current.inputStream
+            result.body = response?.bufferedReader()?.use { reader ->
+                buildString {
+                    var line: String?
+                    while (reader.readLine().also { line = it } != null) append(line).append("\n")
+                }
+            } ?: ""
         } finally {
-          connection?.disconnect()
-          request?.close()
-          responseStream?.close()
-          responseStreamReader?.close()
+            current.disconnect()
+            connection = null
         }
     }
 
+    private fun checkNotAborted() {
+        if (mAbort.get()) throw IOException("Upload has been aborted")
+    }
+
     private fun getMimeType(path: String?): String {
-        var type: String? = null
-        var extension = path?.substringAfterLast('.', "")
-        if (extension != null) {
-            extension = extension.lowercase(Locale.getDefault())
-            if (extension.isNotEmpty()) {
-                type = MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension)
-            }
-        }
-        if (type == null) {
-            type = "*/*"
-        }
-        return type
+        val extension = path?.substringAfterLast('.', "")?.lowercase(Locale.ROOT)
+        return extension?.let { MimeTypeMap.getSingleton().getMimeTypeFromExtension(it) } ?: "*/*"
     }
 
     fun stop() {
         mAbort.set(true)
+        connection?.disconnect()
     }
 }


### PR DESCRIPTION
## Fixes

Write UTF-8 multipart metadata using the same bytes used for Content-Length; use long streaming lengths and a fixed 64 KiB file buffer; close streams on failure; support cancellation and bodyless HTTP error responses; report complete request-body progress.

## Compatibility / breaking changes

BREAKING for native Android implementers of UploadParams.OnUploadProgress: callback parameters change from Int to Long; rebuild/update implementations. JavaScript signatures are unchanged. Progress includes multipart overhead and reaches the full request length. Android stopUpload now aborts and rejects instead of being a no-op. Non-ASCII metadata is correctly UTF-8 encoded.

## Verification

Entire actual Kotlin uploader compiled with Android/HTTP doubles: ASCII and Unicode multipart, raw binary, empty file list, HTTP599 without error stream, cancellation and >2GiB sparse-file lengths. Writes are capped in the large-file diagnostic; this is not a full multi-GB network transfer. Six failing baseline cases become zero. Full Android library compiles against RN0.87.1.

## Shared verification

`yarn test` (ESLint + TypeScript), `yarn prepare` (module/declarations), and `git diff --check` pass for the combined review checkout. React Doctor reports 100/100 for the changed JS scope. Native checks are described above; no physical-device, signed-release or production verification is claimed. No checked-in test/spec files were changed. Isolated diagnostics were run outside the repository. Consumer verification at immutable combined pin eb4ee671c47acc73ce4e84f2d0e19027eb476ff0 (RN 0.87.1): immutable install and lint, both Android Debug flavors, both iOS Simulator Debug schemes, four release-mode Metro bundles, 13 production web builds and four browser-extension builds pass. All 72 installed non-metadata files match reviewed source/rebuilt artifacts. Windows SDK/runtime remains unverified.
