### PR TITLE
fix(android): release transfer jobs and retain redirect settings

### DIFF
--- a/android/src/main/java/com/drpogodin/reactnativefs/Downloader.kt
+++ b/android/src/main/java/com/drpogodin/reactnativefs/Downloader.kt
@@ -8,6 +8,7 @@ import java.io.BufferedReader
 import java.io.FileOutputStream
 import java.io.InputStreamReader
 import java.io.InputStream
+import java.io.IOException
 import java.io.OutputStream
 import java.net.HttpURLConnection
 import java.net.URL
@@ -58,10 +59,23 @@ class Downloader : AsyncTask<DownloadParams?, LongArray?, DownloadResult>() {
             val isRedirect = statusCode != HttpURLConnection.HTTP_OK &&
                     (statusCode == HttpURLConnection.HTTP_MOVED_PERM || statusCode == HttpURLConnection.HTTP_MOVED_TEMP || statusCode == 307 || statusCode == 308)
             if (isRedirect) {
-                val redirectURL = connection.getHeaderField("Location")
+                val location = connection.getHeaderField("Location") ?: throw IOException("Redirect has no Location header")
+                val redirectURL = URL(connection.url, location)
+                val previousURL = connection.url
                 connection.disconnect()
-                connection = URL(redirectURL).openConnection() as HttpURLConnection
-                connection.connectTimeout = 5000
+                connection = redirectURL.openConnection() as HttpURLConnection
+                if (redirectURL.protocol.equals(previousURL.protocol, ignoreCase = true) &&
+                    redirectURL.host.equals(previousURL.host, ignoreCase = true) &&
+                    redirectURL.port.let { if (it == -1) redirectURL.defaultPort else it } ==
+                    previousURL.port.let { if (it == -1) previousURL.defaultPort else it }) {
+                    val redirectHeaders = param.headers!!.keySetIterator()
+                    while (redirectHeaders.hasNextKey()) {
+                        val key = redirectHeaders.nextKey()
+                        connection.setRequestProperty(key, param.headers!!.getString(key))
+                    }
+                }
+                connection.connectTimeout = param.connectionTimeout
+                connection.readTimeout = param.readTimeout
                 connection.connect()
                 statusCode = connection.responseCode
                 lengthOfFile = getContentLength(connection)
@@ -127,16 +141,19 @@ class Downloader : AsyncTask<DownloadParams?, LongArray?, DownloadResult>() {
                 output.flush()
                 res.bytesWritten = total
             } else {
-                responseStream = BufferedInputStream(connection.errorStream)
-                responseStreamReader = BufferedReader(InputStreamReader(responseStream))
-                val stringBuilder = StringBuilder()
-                var line: String?
-                while (responseStreamReader.readLine().also { line = it } != null) {
-                    stringBuilder.append(line).append("\n")
+                val errorStream = connection.errorStream
+                if (errorStream != null) {
+                    responseStream = BufferedInputStream(errorStream)
+                    responseStreamReader = BufferedReader(InputStreamReader(responseStream))
+                    val stringBuilder = StringBuilder()
+                    var line: String?
+                    while (responseStreamReader.readLine().also { line = it } != null) {
+                        stringBuilder.append(line).append("\n")
+                    }
+                    res.body = stringBuilder.toString()
+                } else {
+                    res.body = ""
                 }
-                val response = stringBuilder.toString()
-
-                res!!.body = response
             }
             res.statusCode = statusCode
             res!!.headers = responseHeaders

--- a/android/src/main/java/com/drpogodin/reactnativefs/ReactNativeFsModule.kt
+++ b/android/src/main/java/com/drpogodin/reactnativefs/ReactNativeFsModule.kt
@@ -12,7 +12,6 @@ import android.os.StatFs
 import android.provider.MediaStore
 import android.util.Base64
 import android.util.Base64OutputStream
-import android.util.SparseArray
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts.OpenDocument
 import com.drpogodin.reactnativefs.DownloadParams.OnDownloadBegin
@@ -39,6 +38,7 @@ import java.io.RandomAccessFile
 import java.net.URL
 import java.security.MessageDigest
 import java.util.ArrayDeque
+import java.util.concurrent.ConcurrentHashMap
 
 // TODO: The compilation produces warning:
 //  Note: Some input files use or override a deprecated API.
@@ -46,8 +46,8 @@ import java.util.ArrayDeque
 // It should be taken care of later.
 class ReactNativeFsModule(reactContext: ReactApplicationContext) :
   NativeReactNativeFsSpec(reactContext) {
-    private val downloaders = SparseArray<Downloader>()
-    private val uploaders = SparseArray<Uploader>()
+    private val downloaders = ConcurrentHashMap<Int, Downloader>()
+    private val uploaders = ConcurrentHashMap<Int, Uploader>()
     private val pendingPickFilePromises = ArrayDeque<Promise>()
     private var pickFileLauncher: ActivityResultLauncher<Array<String>>? = null
     private fun getPickFileLauncher(): ActivityResultLauncher<Array<String>> {
@@ -243,6 +243,7 @@ class ReactNativeFsModule(reactContext: ReactApplicationContext) :
             params.connectionTimeout = connectionTimeout
             params.onTaskCompleted = object : OnTaskCompleted {
                 override fun onTaskCompleted(res: DownloadResult?) {
+                    downloaders.remove(jobId)
                     if (res!!.exception == null) {
                         val infoMap = Arguments.createMap()
                         infoMap.putInt("jobId", jobId)
@@ -282,8 +283,13 @@ class ReactNativeFsModule(reactContext: ReactApplicationContext) :
                 }
             }
             val downloader = Downloader()
-            downloader.execute(params)
             downloaders.put(jobId, downloader)
+            try {
+                downloader.execute(params)
+            } catch (ex: Exception) {
+                downloaders.remove(jobId)
+                throw ex
+            }
         } catch (ex: Exception) {
             ex.printStackTrace()
             reject(promise, options.getString("toFile"), ex)
@@ -715,6 +721,7 @@ class ReactNativeFsModule(reactContext: ReactApplicationContext) :
             params.binaryStreamOnly = binaryStreamOnly
             params.onUploadComplete = object : UploadParams.OnUploadComplete {
                 override fun onUploadComplete(res: UploadResult) {
+                    uploaders.remove(jobId)
                     if (res.exception == null) {
                         val infoMap = Arguments.createMap()
                         infoMap.putInt("jobId", jobId)
@@ -750,8 +757,13 @@ class ReactNativeFsModule(reactContext: ReactApplicationContext) :
                 }
             }
             val uploader = Uploader()
-            uploader.execute(params)
             uploaders.put(jobId, uploader)
+            try {
+                uploader.execute(params)
+            } catch (ex: Exception) {
+                uploaders.remove(jobId)
+                throw ex
+            }
         } catch (ex: Exception) {
             ex.printStackTrace()
             reject(promise, options.getString("toUrl"), ex)


### PR DESCRIPTION
## Fixes

Use concurrent active-job maps, register before starting work and remove terminal/failed-start entries. Resolve relative manual redirects; retain configured connect/read timeouts; forward caller headers only to the same origin; return status/body for HTTP errors without an error stream.

## Compatibility / breaking changes

No public signatures change. Completed job IDs no longer retain transfer objects. Same-origin manual redirects retain caller headers; cross-host/port redirects do not receive them. Bodyless HTTP errors return their response status rather than failing with a null-stream error.

## Verification

Entire actual downloader with in-process URLConnection doubles covers relative and absolute same-origin redirects, cross-host/port header isolation, both timeouts, and HTTP599 with no error stream: 5 baseline failures -> 0. Full Android library compilation passes; no real authenticated requests were made.

## Shared verification

`yarn test` (ESLint + TypeScript), `yarn prepare` (module/declarations), and `git diff --check` pass for the combined review checkout. React Doctor reports 100/100 for the changed JS scope. Native checks are described above; no physical-device, signed-release or production verification is claimed. No checked-in test/spec files were changed. Isolated diagnostics were run outside the repository. Consumer verification at immutable combined pin eb4ee671c47acc73ce4e84f2d0e19027eb476ff0 (RN 0.87.1): immutable install and lint, both Android Debug flavors, both iOS Simulator Debug schemes, four release-mode Metro bundles, 13 production web builds and four browser-extension builds pass. All 72 installed non-metadata files match reviewed source/rebuilt artifacts. Windows SDK/runtime remains unverified.
