### PR TITLE
fix(ios): reject upload failures and preserve raw content types

### DIFF
--- a/README.md
+++ b/README.md
@@ -1160,8 +1160,9 @@ function stopUpload(jobId: number): void;
 
 iOS only. Abort the current upload job with given ID.
 
-**NOTE:** Unlike [stopDownload()] it does not cause the pending upload promise
-to reject. Perhaps, we'll change it in future to behave similarly.
+The pending upload promise rejects when cancellation is reported. Handle that
+rejection just like other upload failures. Stopping an already completed job
+has no effect.
 
 - `jobId` &mdash; **number** &mdash; Upload job ID.
 

--- a/ios/ReactNativeFs.mm
+++ b/ios/ReactNativeFs.mm
@@ -798,7 +798,9 @@ NSMutableDictionary<NSValue*,NSArray*> *pendingPickFilePromises;
   bool hasProgressCallback = options.hasProgressCallback();
 
   params.completeCallback = ^(NSString* body, NSURLResponse *resp) {
-    [self.uploaders removeObjectForKey:[jobId stringValue]];
+    @synchronized(self) {
+      [self.uploaders removeObjectForKey:[jobId stringValue]];
+    }
 
     NSMutableDictionary* result = [[NSMutableDictionary alloc] initWithDictionary: @{@"jobId": jobId,
                                                                                      @"body": body}];
@@ -810,7 +812,9 @@ NSMutableDictionary<NSValue*,NSArray*> *pendingPickFilePromises;
   };
 
   params.errorCallback = ^(NSError* error) {
-    [self.uploaders removeObjectForKey:[jobId stringValue]];
+    @synchronized(self) {
+      [self.uploaders removeObjectForKey:[jobId stringValue]];
+    }
     return [[RNFSException fromError:error] reject:reject];
   };
 
@@ -828,18 +832,21 @@ NSMutableDictionary<NSValue*,NSArray*> *pendingPickFilePromises;
     };
   }
 
-  if (!self.uploaders) self.uploaders = [[NSMutableDictionary alloc] init];
-
   RNFSUploader* uploader = [RNFSUploader alloc];
+  @synchronized(self) {
+    if (!self.uploaders) self.uploaders = [[NSMutableDictionary alloc] init];
+    [self.uploaders setValue:uploader forKey:[jobId stringValue]];
+  }
 
   [uploader uploadFiles:params];
-
-  [self.uploaders setValue:uploader forKey:[jobId stringValue]];
 }
 
 - (void) stopUpload:(double)jobId
 {
-  RNFSUploader* uploader = [self.uploaders objectForKey:[[NSNumber numberWithDouble:jobId] stringValue]];
+  RNFSUploader* uploader;
+  @synchronized(self) {
+    uploader = [self.uploaders objectForKey:[[NSNumber numberWithDouble:jobId] stringValue]];
+  }
 
   if (uploader != nil) {
     [uploader stopUpload];

--- a/ios/Uploader.h
+++ b/ios/Uploader.h
@@ -24,7 +24,7 @@ typedef void (^UploadProgressCallback)(NSNumber*, NSNumber*);
 
 @end
 
-@interface RNFSUploader : NSObject <NSURLConnectionDelegate>
+@interface RNFSUploader : NSObject <NSURLSessionTaskDelegate>
 
 - (void)uploadFiles:(RNFSUploadParams*)params;
 - (void)stopUpload;

--- a/ios/Uploader.mm
+++ b/ios/Uploader.mm
@@ -27,7 +27,9 @@
   // set headers
   NSString *formBoundaryString = [self generateBoundaryString];
   NSString *contentType = [NSString stringWithFormat:@"multipart/form-data; boundary=%@", formBoundaryString];
-  [req setValue:contentType forHTTPHeaderField:@"Content-Type"];
+  if (!binaryStreamOnly) {
+    [req setValue:contentType forHTTPHeaderField:@"Content-Type"];
+  }
   for (NSString *key in _params.headers) {
     id val = [_params.headers objectForKey:key];
     if ([val respondsToSelector:@selector(stringValue)]) {
@@ -57,17 +59,16 @@
       return _params.errorCallback(fileError);
     }
 
-    // The default Content-Type set above is multipart; for a raw stream override it
-    // with the file's type (callers may also pass it explicitly via headers).
-    [req setValue:(filetype.length ? filetype : @"application/octet-stream") forHTTPHeaderField:@"Content-Type"];
+    if (![req valueForHTTPHeaderField:@"Content-Type"].length) {
+      [req setValue:(filetype.length ? filetype : @"application/octet-stream") forHTTPHeaderField:@"Content-Type"];
+    }
 
     NSURL *fileURL = [NSURL fileURLWithPath:filepath];
 
     NSURLSessionConfiguration *sessionConfiguration = [NSURLSessionConfiguration defaultSessionConfiguration];
-    NSURLSession *session = [NSURLSession sessionWithConfiguration:sessionConfiguration delegate:(id)self delegateQueue:[NSOperationQueue mainQueue]];
+    NSURLSession *session = [NSURLSession sessionWithConfiguration:sessionConfiguration delegate:self delegateQueue:[NSOperationQueue mainQueue]];
     self->_task = [session uploadTaskWithRequest:req fromFile:fileURL completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-        NSString *str = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
-        return self->_params.completeCallback(str, response);
+        [self completeUploadWithData:data response:response error:error];
     }];
     [self->_task resume];
     [session finishTasksAndInvalidate];
@@ -107,13 +108,13 @@
     // Check if file exists
     NSFileManager *fileManager = [NSFileManager defaultManager];
     if (![fileManager fileExistsAtPath:filepath]){
-      // NSError* error = [NSError errorWithDomain:@"Uploader" code:NSURLErrorFileDoesNotExist userInfo:@{NSLocalizedDescriptionKey: [NSString stringWithFormat: @"Failed to open target file at path: %@", filepath]}];
-      // return _params.errorCallback(error);
-      NSLog(@"Failed to open target file at path: %@", filepath);
-      continue;
+      NSError *error = [NSError errorWithDomain:@"Uploader" code:NSURLErrorFileDoesNotExist userInfo:@{NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Failed to open target file at path: %@", filepath]}];
+      return _params.errorCallback(error);
     }
 
-    NSData *fileData = [NSData dataWithContentsOfFile:filepath];
+    NSError *readError = nil;
+    NSData *fileData = [NSData dataWithContentsOfFile:filepath options:0 error:&readError];
+    if (!fileData) return _params.errorCallback(readError);
     if (!binaryStreamOnly) {
       [reqBody appendData:formBoundaryData];
       [reqBody appendData:[[NSString stringWithFormat:@"Content-Disposition: form-data; name=\"%@\"; filename=\"%@\"\r\n", name.length ? name : filename, filename] dataUsingEncoding:NSUTF8StringEncoding]];
@@ -139,19 +140,28 @@
   }
 
   // send request
+  if (binaryStreamOnly && ![req valueForHTTPHeaderField:@"Content-Type"].length) {
+    [req setValue:@"application/octet-stream" forHTTPHeaderField:@"Content-Type"];
+  }
   [req setHTTPBody:reqBody];
 
   NSURLSessionConfiguration *sessionConfiguration = [NSURLSessionConfiguration defaultSessionConfiguration];
-  NSURLSession *session = [NSURLSession sessionWithConfiguration:sessionConfiguration delegate:(id)self delegateQueue:[NSOperationQueue mainQueue]];
+  NSURLSession *session = [NSURLSession sessionWithConfiguration:sessionConfiguration delegate:self delegateQueue:[NSOperationQueue mainQueue]];
   _task = [session dataTaskWithRequest:req completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-      NSString * str = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
-      return self->_params.completeCallback(str, response);
+      [self completeUploadWithData:data response:response error:error];
   }];
   [_task resume];
   [session finishTasksAndInvalidate];
   if (_params.beginCallback) {
     _params.beginCallback();
   }
+}
+
+- (void)completeUploadWithData:(NSData *)data response:(NSURLResponse *)response error:(NSError *)error
+{
+  if (error) return _params.errorCallback(error);
+  NSString *body = data ? [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding] : nil;
+  _params.completeCallback(body ?: @"", response);
 }
 
 - (NSString *)generateBoundaryString
@@ -179,7 +189,7 @@
   }
 }
 
-- (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task didSendBodyData:(int64_t)bytesSent totalBytesSent:(int64_t)totalBytesSent totalBytesExpectedToSend:(NSInteger)totalBytesExpectedToSend
+- (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task didSendBodyData:(int64_t)bytesSent totalBytesSent:(int64_t)totalBytesSent totalBytesExpectedToSend:(int64_t)totalBytesExpectedToSend
 {
   if (_params.progressCallback) {
     _params.progressCallback([NSNumber numberWithLongLong:totalBytesExpectedToSend], [NSNumber numberWithLongLong:totalBytesSent]);


### PR DESCRIPTION
## Fixes

Handle NSError in both URLSession completion-handler paths; return a non-null response body; reject missing/unreadable multipart files; preserve explicit binary Content-Type; use the correct NSURLSessionTaskDelegate protocol; register upload jobs before synchronous completion and synchronize registry access.

## Compatibility / breaking changes

BREAKING behavioral correction: canceled iOS uploads now reject their pending promise; callers must handle rejection. Network failures and missing multipart files no longer appear successful or silently omit files. Explicit binary Content-Type is respected. Invalid UTF-8 responses yield an empty string, not nil. No JS signature changes.

## Verification

Actual Objective-C uploader with Foundation and session doubles: 8 baseline contract failures -> 0 (network error, cancellation, content type, invalid UTF-8, missing files). A real NSURLSession with an in-process NSURLProtocol confirms completion-handler failures do not call the delegate completion method. Native module registry checks confirm synchronous failures are not reinserted. Actual iOS Simulator SDK compilation passes.

## Shared verification

`yarn test` (ESLint + TypeScript), `yarn prepare` (module/declarations), and `git diff --check` pass for the combined review checkout. React Doctor reports 100/100 for the changed JS scope. Native checks are described above; no physical-device, signed-release or production verification is claimed. No checked-in test/spec files were changed. Isolated diagnostics were run outside the repository. Consumer verification at immutable combined pin eb4ee671c47acc73ce4e84f2d0e19027eb476ff0 (RN 0.87.1): immutable install and lint, both Android Debug flavors, both iOS Simulator Debug schemes, four release-mode Metro bundles, 13 production web builds and four browser-extension builds pass. All 72 installed non-metadata files match reviewed source/rebuilt artifacts. Windows SDK/runtime remains unverified.
