### PR TITLE
fix(ios): preserve download destinations and release completed jobs

### DIFF
--- a/ios/Downloader.mm
+++ b/ios/Downloader.mm
@@ -123,8 +123,16 @@
   NSError *error = nil;
   NSString *responseBodyString = nil;
   if([_statusCode integerValue] >= 200 && [_statusCode integerValue] < 300) {
-    [fm removeItemAtURL:destURL error:nil];       // Remove file at destination path, if it exists
-    [fm moveItemAtURL:location toURL:destURL error:&error];
+    BOOL isDirectory = NO;
+    if ([fm fileExistsAtPath:destURL.path isDirectory:&isDirectory]) {
+      if (isDirectory) {
+        error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileWriteFileExistsError userInfo:@{NSLocalizedDescriptionKey: @"Download destination is a directory"}];
+      } else {
+        [fm replaceItemAtURL:destURL withItemAtURL:location backupItemName:nil options:NSFileManagerItemReplacementUsingNewMetadataOnly resultingItemURL:nil error:&error];
+      }
+    } else {
+      [fm moveItemAtURL:location toURL:destURL error:&error];
+    }
     // There are no guarantees about how often URLSession:downloadTask:didWriteData: will fire,
     // so we read an authoritative number of bytes written here.
     _bytesWritten = @([fm attributesOfItemAtPath:_params.toFile error:nil].fileSize);
@@ -134,10 +142,6 @@
       responseBodyString = [[NSString alloc] initWithData:responseData encoding:NSUTF8StringEncoding];
     }
   }
-  if (error) {
-    NSLog(@"RNFS download: unable to move tempfile to destination. %@, %@", error, error.userInfo);
-  }
-
   // When numerous downloads are called the sessions are not always invalidated and cleared by iOS14.
   // This leads to error 28 – no space left on device so we manually flush and invalidate to free up space
   if(session != nil){
@@ -146,6 +150,7 @@
     }];
   }
 
+  if (error) return _params.errorCallback(error);
   return _params.completeCallback(_statusCode, _bytesWritten, httpResponse.allHeaderFields, responseBodyString);
 }
 
@@ -155,12 +160,12 @@
     NSLog(@"RNFS download: didCompleteWithError %@, %@", error, error.userInfo);
     if (error.code != NSURLErrorCancelled) {
       _resumeData = error.userInfo[NSURLSessionDownloadTaskResumeData];
-      if (_resumeData != nil) {
-        if (_params.resumableCallback) {
-            _params.resumableCallback();
-        }
+      if (_resumeData != nil && _params.resumableCallback) {
+        _params.resumableCallback();
       } else {
-          _params.errorCallback(error);
+        _resumeData = nil;
+        [session finishTasksAndInvalidate];
+        _params.errorCallback(error);
       }
     }
   }

--- a/ios/RNFSBackgroundDownloads.h
+++ b/ios/RNFSBackgroundDownloads.h
@@ -8,6 +8,8 @@
 #ifndef RNFSBackgroundDownloads_h
 #define RNFSBackgroundDownloads_h
 
+#import <Foundation/Foundation.h>
+
 typedef void (^CompletionHandler)(void);
 
 @interface RNFSBackgroundDownloads: NSObject

--- a/ios/RNFSBackgroundDownloads.mm
+++ b/ios/RNFSBackgroundDownloads.mm
@@ -13,17 +13,21 @@ static NSMutableDictionary *completionHandlers;
 
 + (void)complete:(NSString *)uuid
 {
-  CompletionHandler completionHandler = [completionHandlers objectForKey:uuid];
-  if (completionHandler) {
-      completionHandler();
-      [completionHandlers removeObjectForKey:uuid];
+  if (!uuid) return;
+  CompletionHandler completionHandler;
+  @synchronized(self) {
+    completionHandler = [completionHandlers objectForKey:uuid];
+    [completionHandlers removeObjectForKey:uuid];
   }
+  if (completionHandler) completionHandler();
 }
 
 + (void)setCompletionHandlerForIdentifier:(NSString *)identifier completionHandler:(__strong CompletionHandler)completionHandler
 {
-  if (!completionHandlers) completionHandlers = [[NSMutableDictionary alloc] init];
-  [completionHandlers setValue:completionHandler forKey:identifier];
+  @synchronized(self) {
+    if (!completionHandlers) completionHandlers = [[NSMutableDictionary alloc] init];
+    [completionHandlers setValue:completionHandler forKey:identifier];
+  }
 }
 
 @end;

--- a/ios/ReactNativeFs.mm
+++ b/ios/ReactNativeFs.mm
@@ -669,10 +669,11 @@ NSMutableDictionary<NSValue*,NSArray*> *pendingPickFilePromises;
   __block BOOL callbackFired = NO;
 
   params.completeCallback = ^(NSNumber* statusCode, NSNumber* bytesWritten, NSDictionary* headers, NSString* body) {
-    if (callbackFired) {
-      return;
+    @synchronized(self) {
+      if (callbackFired) return;
+      callbackFired = YES;
+      [self.downloaders removeObjectForKey:jobId.stringValue];
     }
-    callbackFired = YES;
 
     NSMutableDictionary* result = [[NSMutableDictionary alloc] initWithDictionary: @{@"jobId": jobId}];
     if (statusCode) {
@@ -691,10 +692,11 @@ NSMutableDictionary<NSValue*,NSArray*> *pendingPickFilePromises;
   };
 
   params.errorCallback = ^(NSError* error) {
-    if (callbackFired) {
-      return;
+    @synchronized(self) {
+      if (callbackFired) return;
+      callbackFired = YES;
+      [self.downloaders removeObjectForKey:jobId.stringValue];
     }
-    callbackFired = YES;
     return [[RNFSException fromError:error] reject:reject];
   };
 
@@ -721,22 +723,28 @@ NSMutableDictionary<NSValue*,NSArray*> *pendingPickFilePromises;
     };
   }
 
-  if (!self.downloaders) self.downloaders = [[NSMutableDictionary alloc] init];
-
   RNFSDownloader* downloader = [RNFSDownloader alloc];
+  @synchronized(self) {
+    if (!self.downloaders) self.downloaders = [[NSMutableDictionary alloc] init];
+    [self.downloaders setObject:downloader forKey:jobId.stringValue];
+  }
 
   NSString *uuid = [downloader downloadFile:params];
 
-  [self.downloaders setValue:downloader forKey:[jobId stringValue]];
-    if (uuid) {
-        if (!self.uuids) self.uuids = [[NSMutableDictionary alloc] init];
-        [self.uuids setValue:uuid forKey:[jobId stringValue]];
+  if (uuid) {
+    @synchronized(self) {
+      if (!self.uuids) self.uuids = [[NSMutableDictionary alloc] init];
+      [self.uuids setObject:uuid forKey:jobId.stringValue];
     }
+  }
 }
 
 - (void) stopDownload:(double)jobId
 {
-  RNFSDownloader* downloader = [self.downloaders objectForKey:[[NSNumber numberWithDouble:jobId] stringValue]];
+  RNFSDownloader* downloader;
+  @synchronized(self) {
+    downloader = [self.downloaders objectForKey:[[NSNumber numberWithDouble:jobId] stringValue]];
+  }
 
   if (downloader != nil) {
     [downloader stopDownload];
@@ -745,7 +753,10 @@ NSMutableDictionary<NSValue*,NSArray*> *pendingPickFilePromises;
 
 - (void) resumeDownload:(double)jobId
 {
-    RNFSDownloader* downloader = [self.downloaders objectForKey:[[NSNumber numberWithDouble:jobId] stringValue]];
+    RNFSDownloader* downloader;
+    @synchronized(self) {
+      downloader = [self.downloaders objectForKey:[[NSNumber numberWithDouble:jobId] stringValue]];
+    }
 
     if (downloader != nil) {
         [downloader resumeDownload];
@@ -756,7 +767,10 @@ NSMutableDictionary<NSValue*,NSArray*> *pendingPickFilePromises;
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject
 {
-    RNFSDownloader* downloader = [self.downloaders objectForKey:[[NSNumber numberWithDouble:jobId] stringValue]];
+    RNFSDownloader* downloader;
+    @synchronized(self) {
+      downloader = [self.downloaders objectForKey:[[NSNumber numberWithDouble:jobId] stringValue]];
+    }
 
     if (downloader != nil) {
         resolve([NSNumber numberWithBool:[downloader isResumable]]);
@@ -767,11 +781,13 @@ NSMutableDictionary<NSValue*,NSArray*> *pendingPickFilePromises;
 
 - (void) completeHandlerIOS:(double)jobId
 {
-    if (self.uuids) {
-        NSNumber *jid = [NSNumber numberWithDouble:jobId];
-        NSString *uuid = [self.uuids objectForKey:[jid stringValue]];
-      [RNFSBackgroundDownloads complete:uuid];
+    NSString *uuid;
+    @synchronized(self) {
+      NSString *key = [[NSNumber numberWithDouble:jobId] stringValue];
+      uuid = [self.uuids objectForKey:key];
+      [self.uuids removeObjectForKey:key];
     }
+    if (uuid) [RNFSBackgroundDownloads complete:uuid];
 }
 
 - (void) uploadFiles:(JS::NativeReactNativeFs::NativeUploadFileOptionsT &)options


### PR DESCRIPTION
## Fixes

Replace existing destination files without first deleting them; refuse directory destinations; propagate move/read failures; reject resumable errors if no resumable handler exists and invalidate terminal sessions. Synchronize job maps, retain only pending/resumable jobs, consume background UUIDs and remove completion handlers before invoking them.

## Compatibility / breaking changes

No public signatures change. Destination errors now reject rather than report success, and failed replacement does not first erase the previous file. Directory contents are preserved. Download failures with resume data but no resumable callback now reject instead of hanging. Background completions are consumed once, including reentrant calls; handlers registered during completion are preserved.

## Verification

Actual downloader + Foundation filesystem diagnostics: new/replaced destinations, missing parent/temp, directory preservation and resume-data/handler combinations (6 failures -> 0). Actual module/background helper checks cover terminal and synchronous cleanup, pending resumable retention, UUID consumption and reentrant/replacement callbacks (6 failures -> 0). Actual iOS Simulator SDK compilation passes. OS background relaunch is not verified.

## Shared verification

`yarn test` (ESLint + TypeScript), `yarn prepare` (module/declarations), and `git diff --check` pass for the combined review checkout. React Doctor reports 100/100 for the changed JS scope. Native checks are described above; no physical-device, signed-release or production verification is claimed. No checked-in test/spec files were changed. Isolated diagnostics were run outside the repository. Consumer verification at immutable combined pin eb4ee671c47acc73ce4e84f2d0e19027eb476ff0 (RN 0.87.1): immutable install and lint, both Android Debug flavors, both iOS Simulator Debug schemes, four release-mode Metro bundles, 13 production web builds and four browser-extension builds pass. All 72 installed non-metadata files match reviewed source/rebuilt artifacts. Windows SDK/runtime remains unverified.
