### PR TITLE
fix(windows): await filesystem work and propagate failures

### DIFF
--- a/windows/ReactNativeFs/RNFSException.cpp
+++ b/windows/ReactNativeFs/RNFSException.cpp
@@ -6,6 +6,6 @@ RNFSException::RNFSException(std::string&& message) {
   this->Message = std::move(message);
 }
 
-const char* RNFSException::what() {
+const char* RNFSException::what() const noexcept {
   return this->Message.c_str();
 }

--- a/windows/ReactNativeFs/RNFSException.h
+++ b/windows/ReactNativeFs/RNFSException.h
@@ -13,7 +13,7 @@ public:
   // fields, we may leverage here. For now, just getting the message is ok.
   RNFSException(std::string&& message);
 
-  virtual const char* what();
+  const char* what() const noexcept override;
 
   template<typename T>
   void reject(ReactPromise<T>& promise) {

--- a/windows/ReactNativeFs/ReactNativeFs.cpp
+++ b/windows/ReactNativeFs/ReactNativeFs.cpp
@@ -242,11 +242,13 @@ try
                 hresult result{ ex.code() };
                 if (result == HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND)) {
                     auto index{ parentPath.find_last_of('\\') };
+                    if (index == std::wstring::npos || index == 0) throw;
                     directoriesToMake.push(parentPath.substr(index + 1));
                     parentPath = parentPath.substr(0, index);
                 }
                 else {
                     promise.Reject(winrt::to_string(ex.message()).c_str());
+                    co_return;
                 }
             }
         }
@@ -431,7 +433,7 @@ try
         {
             StorageFolder src{ co_await StorageFolder::GetFolderFromPathAsync(item.Path()) };
             StorageFolder dest{ co_await destFolder.CreateFolderAsync(item.Name(), CreationCollisionOption::OpenIfExists) };
-            copyFolderHelper(src, dest);
+            co_await copyFolderHelper(src, dest);
         }
     }
 
@@ -444,10 +446,9 @@ catch (const hresult_error& ex)
     promise.Reject(winrt::to_string(ex.message()).c_str());
 }
 
-winrt::fire_and_forget ReactNativeFs::copyFolderHelper(
+winrt::Windows::Foundation::IAsyncAction ReactNativeFs::copyFolderHelper(
     winrt::Windows::Storage::StorageFolder src,
     winrt::Windows::Storage::StorageFolder dest) noexcept
-try
 {
     auto items{ co_await src.GetItemsAsync() };
     for (auto item : items)
@@ -461,13 +462,9 @@ try
         {
             StorageFolder srcFolder{ co_await StorageFolder::GetFolderFromPathAsync(item.Path()) };
             StorageFolder destFolder{ co_await dest.CreateFolderAsync(item.Name(), CreationCollisionOption::OpenIfExists) };
-            copyFolderHelper(srcFolder, destFolder);
+            co_await copyFolderHelper(srcFolder, destFolder);
         }
     }
-}
-catch (...)
-{
-    co_return;
 }
 
 winrt::fire_and_forget ReactNativeFs::getFSInfo(
@@ -551,6 +548,7 @@ catch (const hresult_error& ex)
     hresult result{ ex.code() };
     if (result == HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND)) {
         promise.Resolve(false);
+        co_return;
     }
     // "Failed to check if file or directory exists.
     promise.Reject(winrt::to_string(ex.message()).c_str());
@@ -652,7 +650,7 @@ try
         auto properties{ co_await item.GetBasicPropertiesAsync() };
 
         ReactNativeFsSpec_NativeReadDirResItemT itemInfo;
-        itemInfo.ctime = winrt::clock::to_time_t(targetDirectory.DateCreated());
+        itemInfo.ctime = winrt::clock::to_time_t(item.DateCreated());
         itemInfo.mtime = winrt::clock::to_time_t(properties.DateModified());
         itemInfo.name = to_string(item.Name());
         itemInfo.path = to_string(item.Path());
@@ -689,8 +687,8 @@ try
     Streams::IRandomAccessStream stream{ co_await file.OpenReadAsync() };
     stream.Seek(position);
 
-    stream.ReadAsync(buffer, length, Streams::InputStreamOptions::None);
-    std::string result{ winrt::to_string(Cryptography::CryptographicBuffer::EncodeToBase64String(buffer)) };
+    Streams::IBuffer readBuffer{ co_await stream.ReadAsync(buffer, length, Streams::InputStreamOptions::None) };
+    std::string result{ winrt::to_string(Cryptography::CryptographicBuffer::EncodeToBase64String(readBuffer)) };
 
     promise.Resolve(result);
 }
@@ -802,10 +800,6 @@ catch (const hresult_error& ex)
 winrt::fire_and_forget ReactNativeFs::appendFile(std::wstring filePath, std::wstring base64Content, ReactPromise<void> promise) noexcept
 try
 {
-    size_t fileLength = filePath.length();
-    bool hasTrailingSlash{ filePath[fileLength - 1] == '\\' || filePath[fileLength - 1] == '/' };
-    std::filesystem::path path(hasTrailingSlash ? filePath.substr(0, fileLength - 1) : filePath);
-
     winrt::hstring directoryPath, fileName;
     splitPath(filePath, directoryPath, fileName);
 

--- a/windows/ReactNativeFs/ReactNativeFs.h
+++ b/windows/ReactNativeFs/ReactNativeFs.h
@@ -309,7 +309,7 @@ private:
       uint64_t totalUploadSize
     );
 
-    winrt::fire_and_forget copyFolderHelper(
+    winrt::Windows::Foundation::IAsyncAction copyFolderHelper(
         winrt::Windows::Storage::StorageFolder src,
         winrt::Windows::Storage::StorageFolder dest) noexcept;
 


### PR DESCRIPTION
## Fixes

Await nested folder copies and read completion; propagate recursive copy failures; use the returned read buffer; stop mkdir after terminal errors or non-progressing parent traversal; settle missing-file exists once; report each child creation time; remove unused empty-path indexing; override std::exception::what correctly.

## Compatibility / breaking changes

No JS signatures change. copyFolder resolves only after nested copies finish and rejects their failures. read returns completed bytes rather than an unfilled buffer. Filesystem errors are no longer swallowed or repeatedly settled. Native consumers must rebuild the changed C++ helper interface.

## Verification

Actual copyFolder/helper and read bodies compiled as portable C++20 with delayed WinRT-shaped storage doubles: baseline premature resolution/swallowed nested failures and empty reads reproduce; fixed paths await completion and propagate errors. Other small hunks were source-reviewed. IMPORTANT: no Windows SDK/WinRT build or Windows device run was available on this macOS host; maintainers should run Windows CI before merging.

## Shared verification

`yarn test` (ESLint + TypeScript), `yarn prepare` (module/declarations), and `git diff --check` pass for the combined review checkout. React Doctor reports 100/100 for the changed JS scope. Native checks are described above; no physical-device, signed-release or production verification is claimed. No checked-in test/spec files were changed. Isolated diagnostics were run outside the repository. Consumer verification at immutable combined pin eb4ee671c47acc73ce4e84f2d0e19027eb476ff0 (RN 0.87.1): immutable install and lint, both Android Debug flavors, both iOS Simulator Debug schemes, four release-mode Metro bundles, 13 production web builds and four browser-extension builds pass. All 72 installed non-metadata files match reviewed source/rebuilt artifacts. Windows SDK/runtime remains unverified.
