### PR TITLE
fix(android): close hash and random-access files before settling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1084,11 +1084,9 @@ function readFileRes(filename: string, encoding?: EncodingT): Promise<string>;
 Android-only. Reads the file named `filename` in the Android app's `res` folder
 and return contents. Only the file name (not folder) needs to be specified.
 
-Original docs say: _The file type will be detected from the extension and
-automatically located within `res/drawable` (for image files) or `res/raw`
-(for everything else)._ Good luck with it. The test in the example app does not
-work if the file extension is not included into the filename... but perhaps
-I've overlooked something.
+The file type is detected from the extension and located within `res/drawable`
+(for image files) or `res/raw` (for everything else). Names without an extension
+are looked up in `res/raw`.
 
 - `filename` &mdash; **string** &mdash; Resouce file name.
 - `encoding` &mdash; [EncodingT] &mdash; Optional Encdoing.

--- a/android/src/main/java/com/drpogodin/reactnativefs/ReactNativeFsModule.kt
+++ b/android/src/main/java/com/drpogodin/reactnativefs/ReactNativeFsModule.kt
@@ -365,16 +365,16 @@ class ReactNativeFsModule(reactContext: ReactApplicationContext) :
     }
 
     override fun hash(filepath: String, algorithm: String, promise: Promise) {
-        var inputStream: FileInputStream? = null
         try {
-            val algorithms: MutableMap<String, String> = HashMap()
-            algorithms["md5"] = "MD5"
-            algorithms["sha1"] = "SHA-1"
-            algorithms["sha224"] = "SHA-224"
-            algorithms["sha256"] = "SHA-256"
-            algorithms["sha384"] = "SHA-384"
-            algorithms["sha512"] = "SHA-512"
-            if (!algorithms.containsKey(algorithm)) throw Exception("Invalid hash algorithm")
+            val digestAlgorithm = when (algorithm) {
+                "md5" -> "MD5"
+                "sha1" -> "SHA-1"
+                "sha224" -> "SHA-224"
+                "sha256" -> "SHA-256"
+                "sha384" -> "SHA-384"
+                "sha512" -> "SHA-512"
+                else -> throw Exception("Invalid hash algorithm")
+            }
             val file = File(filepath)
             if (file.isDirectory) {
                 rejectFileIsDirectory(promise)
@@ -384,21 +384,27 @@ class ReactNativeFsModule(reactContext: ReactApplicationContext) :
                 rejectFileNotFound(promise, filepath)
                 return
             }
-            val md = MessageDigest.getInstance(algorithms[algorithm]!!)
-            inputStream = FileInputStream(filepath)
-            val buffer = ByteArray(1024 * 10) // 10 KB Buffer
-            var read: Int
-            while (inputStream.read(buffer).also { read = it } != -1) {
-                md.update(buffer, 0, read)
+            val md = MessageDigest.getInstance(digestAlgorithm)
+            FileInputStream(filepath).use { inputStream ->
+                val buffer = ByteArray(1024 * 10) // 10 KB Buffer
+                var read: Int
+                while (inputStream.read(buffer).also { read = it } != -1) {
+                    md.update(buffer, 0, read)
+                }
             }
-            val hexString = StringBuilder()
-            for (digestByte in md.digest()) hexString.append(String.format("%02x", digestByte))
-            promise.resolve(hexString.toString())
+            val digest = md.digest()
+            val hexDigits = "0123456789abcdef"
+            val hexString = buildString(digest.size * 2) {
+                for (byte in digest) {
+                    val value = byte.toInt() and 0xff
+                    append(hexDigits[value ushr 4])
+                    append(hexDigits[value and 0xf])
+                }
+            }
+            promise.resolve(hexString)
         } catch (ex: Exception) {
             ex.printStackTrace()
             reject(promise, filepath, ex)
-        } finally {
-            inputStream?.close()
         }
     }
 
@@ -758,34 +764,27 @@ class ReactNativeFsModule(reactContext: ReactApplicationContext) :
         }
     }
 
-    // TODO: position arg should be double.
     override fun write(
             filepath: String,
             base64Content: String?,
             position: Double,
             promise: Promise
     ) {
-        var outputStream: OutputStream? = null
-        var file: RandomAccessFile? = null
         try {
             val bytes = Base64.decode(base64Content, Base64.DEFAULT)
             if (position < 0) {
-                outputStream = getOutputStream(filepath, true)
-                outputStream.write(bytes)
+                getOutputStream(filepath, true).use { it.write(bytes) }
             } else {
-                file = RandomAccessFile(filepath, "rw")
-                file.seek(position.toLong())
-                file.write(bytes)
+                RandomAccessFile(filepath, "rw").use { file ->
+                    file.seek(position.toLong())
+                    file.write(bytes)
+                }
             }
             // BEWARE: Output stream must be closed before resolving the promise.
-            outputStream?.close()
             promise.resolve(null)
         } catch (ex: Exception) {
-            outputStream?.close()
             ex.printStackTrace()
             reject(promise, filepath, ex)
-        } finally {
-            file?.close()
         }
     }
 
@@ -933,8 +932,8 @@ class ReactNativeFsModule(reactContext: ReactApplicationContext) :
     }
 
     private fun getResIdentifier(filename: String): Int {
-        val suffix = filename.substring(filename.lastIndexOf(".") + 1)
-        val name = filename.substring(0, filename.lastIndexOf("."))
+        val suffix = filename.substringAfterLast('.', "")
+        val name = filename.substringBeforeLast('.', filename)
         val isImage = suffix == "png" || suffix == "jpg" || suffix == "jpeg" || suffix == "bmp" || suffix == "gif" || suffix == "webp" || suffix == "psd" || suffix == "svg" || suffix == "tiff"
         return reactApplicationContext.resources.getIdentifier(name, if (isImage) "drawable" else "raw", reactApplicationContext.packageName)
     }


### PR DESCRIPTION
## Fixes

Close hash/read and random-access write handles before promise completion. Preserve the original error when closing also fails, and avoid double-close paths. Replace a per-call six-entry hash-algorithm map and per-byte String.format with direct dispatch and hexadecimal character lookup. Accept extensionless raw-resource names; preserve existing extension-based routing and document it.

## Compatibility / observable changes

No public signatures, algorithms or digest output change. Close failures now reject instead of resolving first or escaping after settlement. Extensionless names resolve through res/raw rather than throwing a substring-index error.

## Verification

Actual Kotlin method bodies with real temporary file data and instrumented I/O constructors: all six digest algorithms at 0, 1, 255 and 20,000 bytes match Java MessageDigest/HexFormat; append/random-access writes cover success, write failure, close failure and combined errors. Thirty of 33 baseline lifetime/error checks fail; all 33 fixed cases pass. Four actual resource-name mapping cases pass (one baseline failure). Fewer formatting/map allocations follow directly from the code change; no app-wide speedup is claimed.

## Shared checks and limits

Combined upstream lint/TypeScript and whitespace checks pass. Full Android Kotlin compilation against RN 0.87.1 and all six Apple implementation compilations against the iOS Simulator SDK pass. No checked-in tests/specs changed; diagnostic harnesses live outside the repository. Simulated/native-API-double checks are not physical-device verification. Consumer pin 99772cc04da94d945151415dd296b91c4e5c7807: immutable install/lint, both Android Debug flavors and both iOS Simulator schemes pass. All 72 installed non-metadata files match reviewed source/build artifacts. JS/declarations are unchanged from the preceding verified pin, which passed four Metro bundles, 13 web builds and four extensions. Windows runtime and physical devices remain unverified.
