### PR TITLE
fix(ios): isolate picker promises and reject failed presentation

### DIFF
--- a/ios/ReactNativeFs.mm
+++ b/ios/ReactNativeFs.mm
@@ -21,6 +21,10 @@
 #import "RNFSBackgroundDownloads.h"
 #import "RNFSException.h"
 
+@interface ReactNativeFs ()
+@property (nonatomic, strong) NSMutableDictionary<NSValue*,NSArray*> *pendingPickFilePromises;
+@end
+
 @implementation ReactNativeFs
 
 // The prefix of "Bookmark URLs".
@@ -31,12 +35,10 @@
 // and pass the resulting "Bookmark URLs" string around.
 static NSString *BOOKMARK = @"bookmark://";
 
-NSMutableDictionary<NSValue*,NSArray*> *pendingPickFilePromises;
-
 - (id) init
 {
     if (self = [super init]) {
-        pendingPickFilePromises = [NSMutableDictionary dictionaryWithCapacity:1];
+        _pendingPickFilePromises = [NSMutableDictionary dictionaryWithCapacity:1];
     }
     return self;
 }
@@ -1211,9 +1213,9 @@ NSMutableDictionary<NSValue*,NSArray*> *pendingPickFilePromises;
 didPickDocumentsAtURLs:(NSArray<NSURL *> *)urls
 {
   NSValue *id = [NSValue valueWithPointer:(void*)picker];
-  NSArray *promise = pendingPickFilePromises[id];
+  NSArray *promise = _pendingPickFilePromises[id];
   if (promise != nil) {
-    [pendingPickFilePromises removeObjectForKey:id];
+    [_pendingPickFilePromises removeObjectForKey:id];
     RCTPromiseResolveBlock resolve = promise[0];
     NSMutableArray *res = [NSMutableArray arrayWithCapacity:urls.count];
     for (int i = 0; i < urls.count; ++i) {
@@ -1242,19 +1244,17 @@ didPickDocumentsAtURLs:(NSArray<NSURL *> *)urls
     }
     resolve(res);
   }
-  // TODO: Should crash here, as it is a fatal error.
 }
 
 - (void)documentPickerWasCancelled:(UIDocumentPickerViewController *)picker
 {
   NSValue *id = [NSValue valueWithPointer:(void*)picker];
-  NSArray *promise = pendingPickFilePromises[id];
+  NSArray *promise = _pendingPickFilePromises[id];
   if (promise != nil) {
-    [pendingPickFilePromises removeObjectForKey:id];
+    [_pendingPickFilePromises removeObjectForKey:id];
     RCTPromiseResolveBlock resolve = promise[0];
     resolve(@[]);
   }
-  // TODO: Should crash here, as it is a fatal error.
 }
 #endif
 
@@ -1269,8 +1269,8 @@ didPickDocumentsAtURLs:(NSArray<NSURL *> *)urls
   // See: https://github.com/birdofpreyru/react-native-fs/issues/44
   JS::NativeReactNativeFs::PickFileOptionsT o = options;
   dispatch_async(dispatch_get_main_queue(), ^() {
+    UIDocumentPickerViewController *picker = nil;
     @try {
-      UIDocumentPickerViewController *picker;
 
       facebook::react::LazyVector<NSString*> mimeTypes = o.mimeTypes();
       int numMimeTypes = mimeTypes.size();
@@ -1282,6 +1282,10 @@ didPickDocumentsAtURLs:(NSArray<NSURL *> *)urls
           UTType *type;
           if ([mime isEqual:@"*/*"]) type = UTTypeItem;
           else type = [UTType typeWithMIMEType:mime];
+          if (!type) {
+            reject(@"EINVAL", [NSString stringWithFormat:@"Unsupported MIME type: %@", mime], nil);
+            return;
+          }
           [types addObject:type];
         }
         picker = [[UIDocumentPickerViewController alloc]
@@ -1302,17 +1306,22 @@ didPickDocumentsAtURLs:(NSArray<NSURL *> *)urls
       }
 
       UIViewController *root = RCTPresentedViewController();
+      if (!root) {
+        reject(@"RNFS", @"No view controller is available to present the file picker", nil);
+        return;
+      }
 
       // Note: This is needed because the module overall runs on a dedicated queue
       // (see its methodQueue() method below), while interaction with UI should be
       // done on the main thread queue.
 
       picker.delegate = self;
-      [pendingPickFilePromises setObject:@[resolve, reject]
+      [_pendingPickFilePromises setObject:@[resolve, reject]
                                   forKey:[NSValue valueWithPointer:(void*)picker]];
       [root presentViewController:picker animated:YES completion:nil];
     }
     @catch (NSException *e) {
+      if (picker) [_pendingPickFilePromises removeObjectForKey:[NSValue valueWithPointer:(void*)picker]];
       [[RNFSException fromException:e] reject:reject];
     }
   });


### PR DESCRIPTION
## Fixes

Store pending document-picker promises per module instance instead of in a global dictionary reset by every module initialization. Reject missing presenters and unsupported MIME types. Remove pending entries if presentation throws, and keep duplicate callbacks harmless.

## Compatibility / observable changes

No public signatures change. Missing presenters now reject rather than hang. Invalid MIME types reject EINVAL instead of a generic collection exception. Creating another native module no longer discards or shares a previous instance's picker promises. User cancellation still resolves an empty array.

## Verification

Actual initialization, picker setup and delegate methods compiled/executed with Foundation and UIKit/UTType-shaped doubles: cross-instance initialization, missing presenter, presentation exception cleanup and unsupported MIME type (four baseline failures -> zero). All six Apple implementation files also compile against the real iOS Simulator SDK. Real document-provider UI, security-scoped permissions and device/process restoration are not exercised.

## Shared checks and limits

Combined upstream lint/TypeScript and whitespace checks pass. Full Android Kotlin compilation against RN 0.87.1 and all six Apple implementation compilations against the iOS Simulator SDK pass. No checked-in tests/specs changed; diagnostic harnesses live outside the repository. Simulated/native-API-double checks are not physical-device verification. Consumer pin 99772cc04da94d945151415dd296b91c4e5c7807: immutable install/lint, both Android Debug flavors and both iOS Simulator schemes pass. All 72 installed non-metadata files match reviewed source/build artifacts. JS/declarations are unchanged from the preceding verified pin, which passed four Metro bundles, 13 web builds and four extensions. Windows runtime and physical devices remain unverified.
