### PR TITLE
fix(ios): use UniformTypeIdentifiers instead of deprecated MobileCoreServices C APIs

### DIFF
--- a/ios/Uploader.h
+++ b/ios/Uploader.h
@@ -1,8 +1,5 @@
 #import <Foundation/Foundation.h>
-
-#if !TARGET_OS_OSX
-#import <MobileCoreServices/MobileCoreServices.h>
-#endif
+#import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
 
 typedef void (^UploadCompleteCallback)(NSString*, NSURLResponse *);
 typedef void (^UploadErrorCallback)(NSError*);

--- a/ios/Uploader.mm
+++ b/ios/Uploader.mm
@@ -163,11 +163,13 @@
 - (NSString *)mimeTypeForPath:(NSString *)filepath
 {
   NSString *fileExtension = [filepath pathExtension];
-  NSString *UTI = (__bridge_transfer NSString *)UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, (__bridge CFStringRef)fileExtension, NULL);
-  NSString *contentType = (__bridge_transfer NSString *)UTTypeCopyPreferredTagWithClass((__bridge CFStringRef)UTI, kUTTagClassMIMEType);
 
-  if (contentType) {
-    return contentType;
+  if (@available(iOS 14.0, macOS 11.0, *)) {
+    UTType *type = [UTType typeWithFilenameExtension:fileExtension];
+    NSString *contentType = type.preferredMIMEType;
+    if (contentType) {
+      return contentType;
+    }
   }
   return @"application/octet-stream";
 }


### PR DESCRIPTION
**Problem**
When building this module as a dynamic framework (e.g. using use_frameworks! or use_frameworks! :linkage => :dynamic in CocoaPods), the build fails at link time for arm64 before completing the binary:
```
[ReactNativeFs] Linking ReactNativeFs
❌ Undefined symbols for architecture arm64
❌   "_UTTypeCopyPreferredTagWithClass", referenced from:
❌   "_UTTypeCreatePreferredIdentifierForTag", referenced from:
❌   "_kUTTagClassFilenameExtension", referenced from:
❌   "_kUTTagClassMIMEType", referenced from:
❌ ld: symbol(s) not found for architecture arm64
```
In `ios/Uploader.mm`, `mimeTypeForPath: `uses legacy C functions (`UTTypeCopyPreferredTagWithClass`, `UTTypeCreatePreferredIdentifierForTag`, etc.) to resolve file extensions to MIME types. These symbols live in Apple's legacy `MobileCoreServices.framework` on iOS (and `CoreServices.framework` on macOS).

When dynamic frameworks are enabled, CocoaPods strictly isolates the framework targets and won't transitively link unreferenced system frameworks. Because `ReactNativeFs.podspec` already declares `UniformTypeIdentifiers` in `s.frameworks` but omits `MobileCoreServices`, the linker is not passed `-framework MobileCoreServices`, causing the undefined symbol failure.

Furthermore, Apple officially deprecated these C APIs in iOS 15 / macOS 12 in favor of the modern `UniformTypeIdentifiers` framework.

**Change**
Instead of adding legacy platform-specific dependencies (`MobileCoreServices` for iOS and `CoreServices` for macOS) to the podspec, we modernize the implementation to use the `UniformTypeIdentifiers` framework that is already declared in `s.frameworks`:
```c
- (NSString *)mimeTypeForPath:(NSString *)filepath
{
  NSString *fileExtension = [filepath pathExtension];

  if (@available(iOS 14.0, macOS 11.0, *)) {
    UTType *type = [UTType typeWithFilenameExtension:fileExtension];
    NSString *contentType = type.preferredMIMEType;
    if (contentType) {
      return contentType;
    }
  }
  return @"application/octet-stream";
}
```

Files changed:

`ios/Uploader.h `(replace `#import <MobileCoreServices/...>` with #import <UniformTypeIdentifiers/...>)
`ios/Uploader.mm` (replace legacy C functions with `[UTType typeWithFilenameExtension:]`)


  | Legacy C API (Previous) | `UniformTypeIdentifiers` (This PR)
-- | -- | --
Framework | `MobileCoreServices` (iOS) / `CoreServices` (macOS) | `UniformTypeIdentifiers` (Universal)
Podspec status | Missing (linker fails with dynamic frameworks) | Already present in `s.frameworks`
Apple Support | Deprecated in iOS 15 / macOS 12 | Standard API since iOS 14 / macOS 11
Memory / Safety | Manual CoreFoundation bridge casts (`__bridge_transfer`) | Native ARC Objective-C object
Fallback behavior | `"application/octet-stream"` | `"application/octet-stream"` (Unchanged)

**What I verified, and what I did not**
Verified on a real React Native project configured with dynamic frameworks (`USE_FRAMEWORKS=dynamic` / `use_frameworks! :linkage => :dynamic`):
Cleaned CocoaPods cache and re-installed pods.
`Linking ReactNativeFs` succeeds on `arm64` iOS Simulator and physical device builds with zero missing symbol errors.
Confirmed MIME resolution works as expected for common extensions (`.png`, `.jpg`, `.pdf`, `.mp4`) and safely falls back to `application/octet-stream` for extensionless/unknown files.
Not run: macOS target (`react-native-macos`) or standalone repository example app.